### PR TITLE
- Adjusted size of profile picture (was too small)

### DIFF
--- a/ChoresForCoinsiOS/Main.storyboard
+++ b/ChoresForCoinsiOS/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="b6P-mi-Mj5">
-    <device id="ipad9_7" orientation="landscape">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -19,20 +19,20 @@
             <objects>
                 <viewController storyboardIdentifier="choreListTab" id="0aj-d2-s3B" customClass="ChoreListViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="MmR-Ow-AS6">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="W9a-Zf-rVU">
-                                <rect key="frame" x="0.0" y="-14.5" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="-14.5" width="768" height="1024"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cf5-cM-o3q" userLabel="choreListTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="54"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="xgm-C1-b2L">
-                                        <rect key="frame" x="0.0" y="0.0" width="1024" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="71.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x0w-Ri-WMW">
-                                        <rect key="frame" x="8" y="8" width="37" height="37"/>
+                                        <rect key="frame" x="8" y="10.5" width="49.5" height="49.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="x0w-Ri-WMW" secondAttribute="height" id="cPH-qB-Mtc"/>
                                         </constraints>
@@ -42,7 +42,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y9N-Eh-TMa">
-                                        <rect key="frame" x="53" y="11" width="120" height="30"/>
+                                        <rect key="frame" x="65.5" y="20" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -51,7 +51,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vJj-gy-wFi">
-                                        <rect key="frame" x="948" y="12" width="17" height="30"/>
+                                        <rect key="frame" x="678" y="20" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -60,7 +60,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gd8-wI-BD1">
-                                        <rect key="frame" x="973" y="5" width="43" height="42.5"/>
+                                        <rect key="frame" x="703" y="6.5" width="57" height="57"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="Gd8-wI-BD1" secondAttribute="height" id="R6o-zE-8CN"/>
                                         </constraints>
@@ -70,7 +70,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="xWf-De-OuA">
-                                        <rect key="frame" x="1003" y="5" width="13" height="13"/>
+                                        <rect key="frame" x="742.5" y="6.5" width="17.5" height="17.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="xWf-De-OuA" secondAttribute="height" multiplier="1:1" id="lwv-Ki-fOh"/>
                                         </constraints>
@@ -100,16 +100,16 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gxq-DE-bZS">
-                                <rect key="frame" x="0.0" y="74" width="1024" height="645"/>
+                                <rect key="frame" x="0.0" y="91.5" width="768" height="883.5"/>
                                 <connections>
                                     <segue destination="qkR-R1-FEZ" kind="embed" id="1DJ-Nh-2JN"/>
                                 </connections>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hu1-17-zjp" userLabel="RedeemChildView">
-                                <rect key="frame" x="512" y="66" width="512" height="76.5"/>
+                                <rect key="frame" x="560.5" y="83.5" width="207.5" height="102.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dg4-dM-SJT">
-                                        <rect key="frame" x="0.0" y="14.5" width="512" height="48"/>
+                                        <rect key="frame" x="0.0" y="27.5" width="207.5" height="48"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                         <state key="normal" title="REDEEM">
                                             <color key="titleColor" red="0.13273318527918787" green="0.13273318527918787" blue="0.13273318527918787" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -143,10 +143,22 @@
                             <constraint firstItem="W9a-Zf-rVU" firstAttribute="centerX" secondItem="xOL-dX-BLh" secondAttribute="centerX" id="lY0-Ja-6Vg"/>
                             <constraint firstItem="hu1-17-zjp" firstAttribute="top" secondItem="cf5-cM-o3q" secondAttribute="bottom" constant="-8" id="mtD-5E-mss"/>
                             <constraint firstItem="hu1-17-zjp" firstAttribute="height" secondItem="MmR-Ow-AS6" secondAttribute="height" multiplier="0.1" id="tnn-uU-ml1"/>
+                            <constraint firstItem="hu1-17-zjp" firstAttribute="width" secondItem="MmR-Ow-AS6" secondAttribute="width" multiplier="0.27" id="wRv-kL-sDW"/>
                             <constraint firstItem="xOL-dX-BLh" firstAttribute="trailing" secondItem="Gxq-DE-bZS" secondAttribute="trailing" id="xDh-1b-GHJ"/>
                             <constraint firstItem="W9a-Zf-rVU" firstAttribute="height" secondItem="MmR-Ow-AS6" secondAttribute="height" id="yHK-tQ-gmU"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="xOL-dX-BLh"/>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="wRv-kL-sDW"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="VlD-3J-SNU"/>
+                                <include reference="wRv-kL-sDW"/>
+                            </mask>
+                        </variation>
                     </view>
                     <tabBarItem key="tabBarItem" title="Chore List" image="iconChoreList_Sinactive" selectedImage="iconChoreList_S" id="d3l-og-cKF">
                         <color key="badgeColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -171,11 +183,11 @@
             <objects>
                 <viewController id="QRy-ch-Cyl" customClass="ProfileEditViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jGO-P4-ICA">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="v9s-iV-mDm">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oAr-jW-aLg">
                                 <rect key="frame" x="8" y="20" width="48" height="30"/>
@@ -185,10 +197,10 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HsM-2G-TSf" userLabel="UpdateProfilePicView">
-                                <rect key="frame" x="0.0" y="50" width="1024" height="292"/>
+                                <rect key="frame" x="0.0" y="50" width="768" height="389"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XP8-Hg-WXt">
-                                        <rect key="frame" x="394" y="28" width="236" height="236"/>
+                                        <rect key="frame" x="230.5" y="41" width="307.5" height="307.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="XP8-Hg-WXt" secondAttribute="height" multiplier="1:1" id="SXo-8s-K6m"/>
                                         </constraints>
@@ -211,41 +223,41 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oBx-dk-ZAg" userLabel="updateFormView">
-                                <rect key="frame" x="0.0" y="342" width="1024" height="226.5"/>
+                                <rect key="frame" x="0.0" y="439" width="768" height="319"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fvp-4L-aBR">
-                                        <rect key="frame" x="256.5" y="98" width="512" height="30"/>
+                                        <rect key="frame" x="192.5" y="144" width="384" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rRS-Tp-gT1">
-                                        <rect key="frame" x="256" y="73" width="512.5" height="17"/>
+                                        <rect key="frame" x="192" y="119" width="384.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GxR-fO-VoJ">
-                                        <rect key="frame" x="256" y="24" width="512.5" height="30"/>
+                                        <rect key="frame" x="192" y="50" width="384.5" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qOf-lS-q0a">
-                                        <rect key="frame" x="256" y="-1" width="512.5" height="17"/>
+                                        <rect key="frame" x="192" y="25" width="384.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uLR-3F-zU1">
-                                        <rect key="frame" x="0.0" y="136" width="1024" height="30"/>
+                                        <rect key="frame" x="0.0" y="182" width="768" height="30"/>
                                         <state key="normal" title="Update Password"/>
                                         <connections>
                                             <action selector="updatePassword:" destination="QRy-ch-Cyl" eventType="touchUpInside" id="i9f-eR-KJk"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rFg-dU-CR4">
-                                        <rect key="frame" x="0.5" y="174" width="1024" height="30"/>
+                                        <rect key="frame" x="0.5" y="220" width="768" height="30"/>
                                         <state key="normal" title="Send Parent Key"/>
                                         <connections>
                                             <action selector="sendParentKey:" destination="QRy-ch-Cyl" eventType="touchUpInside" id="6sR-e2-Qzt"/>
@@ -287,10 +299,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Aw-hO-q0u" userLabel="UpdateSaveButtonView">
-                                <rect key="frame" x="0.0" y="645" width="1024" height="65.5"/>
+                                <rect key="frame" x="0.0" y="860" width="768" height="87"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sq5-8C-hxB">
-                                        <rect key="frame" x="350.5" y="14" width="322" height="38.5"/>
+                                        <rect key="frame" x="223.5" y="18" width="322" height="52.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title=" SAVE" backgroundImage="btnOrange_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -314,10 +326,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D40-R6-V2q" userLabel="UpdateLogoutView">
-                                <rect key="frame" x="0.0" y="710.5" width="1024" height="57.5"/>
+                                <rect key="frame" x="0.0" y="947" width="768" height="77"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abi-MV-LDy">
-                                        <rect key="frame" x="481" y="14" width="62" height="30"/>
+                                        <rect key="frame" x="353" y="24" width="62" height="30"/>
                                         <state key="normal" title="LOGOUT">
                                             <color key="titleColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
@@ -333,16 +345,16 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Agh-f6-t7H">
-                                <rect key="frame" x="0.0" y="568.5" width="1024" height="76.5"/>
+                                <rect key="frame" x="0.0" y="758" width="768" height="102"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PARENT KEY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rPb-bS-wMk">
-                                        <rect key="frame" x="351" y="26.5" width="322" height="22"/>
+                                        <rect key="frame" x="223" y="40" width="322" height="22"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parent Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HZT-Xp-a36">
-                                        <rect key="frame" x="351" y="-5.5" width="322" height="17"/>
+                                        <rect key="frame" x="223" y="8" width="322" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -368,7 +380,7 @@
                         <constraints>
                             <constraint firstItem="v9s-iV-mDm" firstAttribute="centerY" secondItem="Ns7-I5-yH5" secondAttribute="centerY" id="0y7-Yg-NYB"/>
                             <constraint firstItem="oAr-jW-aLg" firstAttribute="top" secondItem="Ns7-I5-yH5" secondAttribute="top" id="1b0-c7-Q8R"/>
-                            <constraint firstItem="XP8-Hg-WXt" firstAttribute="width" secondItem="jGO-P4-ICA" secondAttribute="width" multiplier="0.23" id="51z-pe-fdA"/>
+                            <constraint firstItem="XP8-Hg-WXt" firstAttribute="width" secondItem="jGO-P4-ICA" secondAttribute="width" multiplier="0.4" id="51z-pe-fdA"/>
                             <constraint firstItem="oBx-dk-ZAg" firstAttribute="top" secondItem="HsM-2G-TSf" secondAttribute="bottom" id="5Ar-ca-Ypw"/>
                             <constraint firstItem="D40-R6-V2q" firstAttribute="leading" secondItem="Ns7-I5-yH5" secondAttribute="leading" id="5DL-Xg-AWK"/>
                             <constraint firstItem="Agh-f6-t7H" firstAttribute="leading" secondItem="Ns7-I5-yH5" secondAttribute="leading" id="5zY-Pe-wpV"/>
@@ -431,20 +443,20 @@
             <objects>
                 <viewController storyboardIdentifier="overviewVC" id="Y1B-Nd-lxC" customClass="OverviewViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8sQ-Md-49K">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="4HW-PK-3pI">
-                                <rect key="frame" x="0.0" y="-14.5" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="-14.5" width="768" height="1024"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="az5-xB-cew" userLabel="CalcTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="54"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="Upn-VF-ECv">
-                                        <rect key="frame" x="0.0" y="0.0" width="1024" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="71.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zWJ-hv-vM4">
-                                        <rect key="frame" x="8" y="8" width="37" height="37"/>
+                                        <rect key="frame" x="8" y="10.5" width="49.5" height="49.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="zWJ-hv-vM4" secondAttribute="height" id="Yll-T4-atn"/>
                                         </constraints>
@@ -454,7 +466,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="smS-2V-AfQ">
-                                        <rect key="frame" x="53" y="12" width="120" height="30"/>
+                                        <rect key="frame" x="65.5" y="21" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -463,7 +475,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dCw-3C-Dbx">
-                                        <rect key="frame" x="948" y="12" width="17" height="30"/>
+                                        <rect key="frame" x="677" y="20" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -472,7 +484,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UXJ-Lu-ATg">
-                                        <rect key="frame" x="973" y="5" width="42.5" height="42.5"/>
+                                        <rect key="frame" x="702" y="6.5" width="57.5" height="57"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="UXJ-Lu-ATg" secondAttribute="height" id="qVZ-lt-nN9"/>
                                         </constraints>
@@ -482,7 +494,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="DSO-yv-s7n">
-                                        <rect key="frame" x="1003" y="5" width="12.5" height="13"/>
+                                        <rect key="frame" x="742.5" y="6.5" width="17" height="17.5"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -510,21 +522,21 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fCU-Hl-8CR">
-                                <rect key="frame" x="0.0" y="74" width="1024" height="645"/>
+                                <rect key="frame" x="0.0" y="91.5" width="768" height="883.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" rowHeight="493" id="cpW-Qp-FtB" customClass="OverviewTableViewCell" customModule="ChoresForCoinsiOS" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="1024" height="493"/>
+                                        <rect key="frame" x="0.0" y="28" width="768" height="493"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cpW-Qp-FtB" id="hx6-Kl-s94">
-                                            <rect key="frame" x="0.0" y="0.0" width="1024" height="492.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="768" height="492.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AVT-ib-Csk" userLabel="UsernameHeaderView">
-                                                    <rect key="frame" x="15" y="11" width="994" height="74"/>
+                                                    <rect key="frame" x="15" y="11" width="738" height="74"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bzX-Ne-L1s">
-                                                            <rect key="frame" x="0.0" y="0.0" width="994" height="74"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="738" height="74"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -538,22 +550,18 @@
                                                         <constraint firstAttribute="trailing" secondItem="bzX-Ne-L1s" secondAttribute="trailing" id="ozx-0g-vQr"/>
                                                     </constraints>
                                                 </view>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9ka-Fc-yBm" customClass="LineChartView" customModule="Charts">
-                                                    <rect key="frame" x="8" y="290" width="359" height="195"/>
-                                                    <color key="backgroundColor" red="0.57045853140000002" green="0.57047235969999999" blue="0.57046490910000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tOV-3O-DQA" userLabel="PieChartsView">
-                                                    <rect key="frame" x="0.0" y="85" width="307.5" height="407.5"/>
+                                                    <rect key="frame" x="0.0" y="85" width="230.5" height="407.5"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VfS-j8-G8V" userLabel="CoinPieChartView" customClass="PieChartView" customModule="Charts">
-                                                            <rect key="frame" x="22" y="0.0" width="246" height="246"/>
+                                                            <rect key="frame" x="22" y="0.0" width="184.5" height="184.5"/>
                                                             <color key="backgroundColor" red="0.75406885150000003" green="0.75408679249999999" blue="0.75407713649999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="VfS-j8-G8V" secondAttribute="height" id="nqO-Fa-F1f"/>
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4zm-qo-ixT" userLabel="ChoresDoneChartView" customClass="PieChartView" customModule="Charts">
-                                                            <rect key="frame" x="22" y="262" width="246" height="245.5"/>
+                                                            <rect key="frame" x="21.5" y="200.5" width="185" height="185"/>
                                                             <color key="backgroundColor" red="0.75406885150000003" green="0.75408679249999999" blue="0.75407713649999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="4zm-qo-ixT" secondAttribute="height" multiplier="1:1" id="i9T-vw-izC"/>
@@ -602,6 +610,10 @@
                                                         </mask>
                                                     </variation>
                                                 </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9ka-Fc-yBm" customClass="LineChartView" customModule="Charts">
+                                                    <rect key="frame" x="238.5" y="93" width="521.5" height="391.5"/>
+                                                    <color key="backgroundColor" red="0.57045853140000002" green="0.57047235969999999" blue="0.57046490910000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </view>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="tOV-3O-DQA" firstAttribute="top" secondItem="AVT-ib-Csk" secondAttribute="bottom" id="5JH-Qb-ApK"/>
@@ -612,12 +624,16 @@
                                                 <constraint firstAttribute="trailingMargin" secondItem="AVT-ib-Csk" secondAttribute="trailing" id="J2y-TX-vxi"/>
                                                 <constraint firstItem="tOV-3O-DQA" firstAttribute="leading" secondItem="hx6-Kl-s94" secondAttribute="leading" constant="8" id="LMv-if-WbH"/>
                                                 <constraint firstItem="tOV-3O-DQA" firstAttribute="top" secondItem="AVT-ib-Csk" secondAttribute="bottom" id="N76-5v-IkX"/>
+                                                <constraint firstAttribute="trailing" secondItem="9ka-Fc-yBm" secondAttribute="trailing" constant="8" id="Rhy-pH-YD1"/>
+                                                <constraint firstItem="9ka-Fc-yBm" firstAttribute="top" secondItem="AVT-ib-Csk" secondAttribute="bottom" constant="8" id="WHL-Ox-As9"/>
                                                 <constraint firstItem="AVT-ib-Csk" firstAttribute="leading" secondItem="hx6-Kl-s94" secondAttribute="leadingMargin" id="XTk-Wt-KP0"/>
+                                                <constraint firstAttribute="bottom" secondItem="9ka-Fc-yBm" secondAttribute="bottom" constant="8" id="b6Q-l4-nUL"/>
                                                 <constraint firstAttribute="bottom" secondItem="9ka-Fc-yBm" secondAttribute="bottom" constant="8" id="dWe-JZ-tgh"/>
                                                 <constraint firstItem="9ka-Fc-yBm" firstAttribute="top" secondItem="tOV-3O-DQA" secondAttribute="bottom" constant="8" id="h3E-Ld-BQc"/>
                                                 <constraint firstItem="9ka-Fc-yBm" firstAttribute="leading" secondItem="hx6-Kl-s94" secondAttribute="leading" constant="8" id="hFQ-nP-wOF"/>
                                                 <constraint firstAttribute="trailing" secondItem="tOV-3O-DQA" secondAttribute="trailing" constant="8" id="mj1-NH-cAu"/>
-                                                <constraint firstItem="tOV-3O-DQA" firstAttribute="height" secondItem="hx6-Kl-s94" secondAttribute="height" multiplier="0.4" id="owf-Iu-t4V"/>
+                                                <constraint firstItem="9ka-Fc-yBm" firstAttribute="leading" secondItem="tOV-3O-DQA" secondAttribute="trailing" constant="8" id="nbO-9g-6PX"/>
+                                                <constraint firstItem="tOV-3O-DQA" firstAttribute="height" secondItem="hx6-Kl-s94" secondAttribute="height" multiplier="0.35" id="owf-Iu-t4V"/>
                                                 <constraint firstAttribute="bottom" secondItem="tOV-3O-DQA" secondAttribute="bottom" id="qF3-ds-HvP"/>
                                                 <constraint firstItem="tOV-3O-DQA" firstAttribute="width" secondItem="hx6-Kl-s94" secondAttribute="width" multiplier="0.3" id="vRj-90-Sam"/>
                                             </constraints>
@@ -627,6 +643,10 @@
                                                     <exclude reference="N76-5v-IkX"/>
                                                     <exclude reference="qF3-ds-HvP"/>
                                                     <exclude reference="vRj-90-Sam"/>
+                                                    <exclude reference="Rhy-pH-YD1"/>
+                                                    <exclude reference="WHL-Ox-As9"/>
+                                                    <exclude reference="b6Q-l4-nUL"/>
+                                                    <exclude reference="nbO-9g-6PX"/>
                                                 </mask>
                                             </variation>
                                             <variation key="heightClass=regular-widthClass=regular">
@@ -639,8 +659,14 @@
                                                     <exclude reference="owf-Iu-t4V"/>
                                                     <include reference="qF3-ds-HvP"/>
                                                     <include reference="vRj-90-Sam"/>
+                                                    <exclude reference="76n-pk-Zv6"/>
+                                                    <include reference="Rhy-pH-YD1"/>
+                                                    <include reference="WHL-Ox-As9"/>
+                                                    <include reference="b6Q-l4-nUL"/>
+                                                    <exclude reference="dWe-JZ-tgh"/>
                                                     <exclude reference="h3E-Ld-BQc"/>
                                                     <exclude reference="hFQ-nP-wOF"/>
+                                                    <include reference="nbO-9g-6PX"/>
                                                 </mask>
                                             </variation>
                                         </tableViewCellContentView>
@@ -658,11 +684,10 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6V1-h8-w1V" userLabel="RedeemChildView">
-                                <rect key="frame" x="512" y="66" width="512" height="76.5"/>
+                                <rect key="frame" x="560.5" y="83.5" width="207.5" height="102.5"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="doc-xP-KK3">
-                                        <rect key="frame" x="0.0" y="17" width="187.33333333333334" height="48"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="doc-xP-KK3">
+                                        <rect key="frame" x="0.0" y="27.5" width="207.5" height="48"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                         <state key="normal" title="REDEEM">
                                             <color key="titleColor" red="0.1327331853" green="0.1327331853" blue="0.1327331853" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -673,6 +698,11 @@
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="0.79917594179999996" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstItem="doc-xP-KK3" firstAttribute="centerX" secondItem="6V1-h8-w1V" secondAttribute="centerX" id="Tmd-82-O6x"/>
+                                    <constraint firstItem="doc-xP-KK3" firstAttribute="width" secondItem="6V1-h8-w1V" secondAttribute="width" id="ZSB-Xc-ayk"/>
+                                    <constraint firstItem="doc-xP-KK3" firstAttribute="centerY" secondItem="6V1-h8-w1V" secondAttribute="centerY" id="qoV-lm-t8o"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -692,9 +722,21 @@
                             <constraint firstItem="4HW-PK-3pI" firstAttribute="centerY" secondItem="qnb-AD-Rqv" secondAttribute="centerY" id="hAb-ux-hur"/>
                             <constraint firstItem="qnb-AD-Rqv" firstAttribute="bottom" secondItem="fCU-Hl-8CR" secondAttribute="bottom" id="hfP-cv-N7K"/>
                             <constraint firstItem="6V1-h8-w1V" firstAttribute="height" secondItem="8sQ-Md-49K" secondAttribute="height" multiplier="0.1" id="mHD-9j-wp0"/>
+                            <constraint firstItem="6V1-h8-w1V" firstAttribute="width" secondItem="8sQ-Md-49K" secondAttribute="width" multiplier="0.27" id="njw-V1-m59"/>
                             <constraint firstItem="fCU-Hl-8CR" firstAttribute="leading" secondItem="qnb-AD-Rqv" secondAttribute="leading" id="qoe-RI-60w"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="qnb-AD-Rqv"/>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="njw-V1-m59"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="0Ga-wI-T2z"/>
+                                <include reference="njw-V1-m59"/>
+                            </mask>
+                        </variation>
                     </view>
                     <tabBarItem key="tabBarItem" title="Overview" image="iconOverview_Sinactive" selectedImage="iconOverview_S" id="Fc2-xT-rJ3">
                         <color key="badgeColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -719,18 +761,18 @@
             <objects>
                 <viewController id="4xr-Yg-kUN" customClass="AddChoreViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dNn-bG-5ps">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="Hns-AM-LnV">
-                                <rect key="frame" x="0.0" y="-14.5" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="-14.5" width="768" height="1024"/>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OYy-DR-0ue" userLabel="ChoreNameView">
-                                <rect key="frame" x="0.0" y="74" width="1024" height="61"/>
+                                <rect key="frame" x="0.0" y="91.5" width="768" height="82"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="CHORE NAME" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dWX-Jq-LEa">
-                                        <rect key="frame" x="103" y="10.5" width="819" height="40"/>
+                                        <rect key="frame" x="77.5" y="21" width="614" height="40"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                         <textInputTraits key="textInputTraits"/>
@@ -747,10 +789,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ftx-ku-Nrh" userLabel="UsernameView">
-                                <rect key="frame" x="0.0" y="142.5" width="1024" height="46"/>
+                                <rect key="frame" x="0.0" y="186" width="768" height="61.5"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bT4-0k-dzp">
-                                        <rect key="frame" x="103" y="7" width="819" height="33"/>
+                                        <rect key="frame" x="77.5" y="15" width="614" height="33"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <textInputTraits key="textInputTraits"/>
@@ -767,10 +809,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OXt-Dh-6lA" userLabel="DescriptionView">
-                                <rect key="frame" x="0.0" y="188.5" width="1024" height="192"/>
+                                <rect key="frame" x="0.0" y="247.5" width="768" height="256"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Chore Description" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="5P0-uy-DTh">
-                                        <rect key="frame" x="51.5" y="0.0" width="921" height="192"/>
+                                        <rect key="frame" x="38.5" y="0.0" width="691" height="256"/>
                                         <color key="backgroundColor" white="1" alpha="0.49068921232876711" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -788,13 +830,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="80r-pS-eBE" userLabel="DatesView">
-                                <rect key="frame" x="0.0" y="380.5" width="1024" height="115.5"/>
+                                <rect key="frame" x="0.0" y="503.5" width="768" height="153.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E5M-Ns-iIe">
-                                        <rect key="frame" x="0.0" y="0.0" width="338" height="115.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="253.5" height="153.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yhz-DH-uHb">
-                                                <rect key="frame" x="34" y="11" width="270.5" height="24"/>
+                                                <rect key="frame" x="25.5" y="30" width="203" height="24"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -803,7 +845,7 @@
                                                 </variation>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JaL-6P-NFh">
-                                                <rect key="frame" x="34" y="43" width="270" height="30"/>
+                                                <rect key="frame" x="25.5" y="62" width="202.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -823,10 +865,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b90-Wz-xCB">
-                                        <rect key="frame" x="338" y="0.0" width="348" height="115.5"/>
+                                        <rect key="frame" x="253.5" y="0.0" width="261" height="153.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Due Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="njc-c3-r4h">
-                                                <rect key="frame" x="34" y="11" width="279" height="24"/>
+                                                <rect key="frame" x="25.5" y="30" width="209" height="24"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -835,7 +877,7 @@
                                                 </variation>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="meV-cH-eqE">
-                                                <rect key="frame" x="34.5" y="43" width="279" height="30"/>
+                                                <rect key="frame" x="26" y="62" width="209" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -855,10 +897,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b3f-en-d2E">
-                                        <rect key="frame" x="686" y="0.0" width="338" height="115.5"/>
+                                        <rect key="frame" x="514.5" y="0.0" width="253.5" height="153.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chore Value" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OX9-Jf-wwA">
-                                                <rect key="frame" x="34" y="9" width="270" height="24"/>
+                                                <rect key="frame" x="25.5" y="28" width="202.5" height="24"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -867,7 +909,7 @@
                                                 </variation>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="10" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ovw-Si-pQS">
-                                                <rect key="frame" x="34" y="41" width="270" height="34"/>
+                                                <rect key="frame" x="25.5" y="60" width="202.5" height="34"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
@@ -906,14 +948,14 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GpQ-N3-WGT" userLabel="BottomButtonsView">
-                                <rect key="frame" x="0.0" y="657.5" width="1024" height="61.5"/>
+                                <rect key="frame" x="0.0" y="893" width="768" height="82"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s3z-rf-xad">
-                                        <rect key="frame" x="481.5" y="28" width="61" height="6"/>
+                                        <rect key="frame" x="361" y="37.5" width="46" height="8"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U7Z-Nl-tJ6">
-                                        <rect key="frame" x="102.5" y="7" width="819.5" height="49"/>
+                                        <rect key="frame" x="77" y="9" width="614.5" height="65.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="SAVE" backgroundImage="btnGreen_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -936,13 +978,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oAR-Uz-Bxr" userLabel="CalcTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="54"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="rHR-Mc-Ztb">
-                                        <rect key="frame" x="0.0" y="0.0" width="1024" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="71.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ITP-Cg-ahr">
-                                        <rect key="frame" x="8" y="8" width="37" height="37"/>
+                                        <rect key="frame" x="8" y="10.5" width="49.5" height="49.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="ITP-Cg-ahr" secondAttribute="height" id="fK5-OU-2sY"/>
                                         </constraints>
@@ -952,7 +994,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L9L-lR-LBL">
-                                        <rect key="frame" x="53" y="12" width="120" height="30"/>
+                                        <rect key="frame" x="65.5" y="21" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -961,7 +1003,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G6P-CT-eX6">
-                                        <rect key="frame" x="948" y="12" width="17" height="30"/>
+                                        <rect key="frame" x="678" y="20" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -970,7 +1012,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7JA-pm-tBE">
-                                        <rect key="frame" x="973" y="5" width="43" height="42.5"/>
+                                        <rect key="frame" x="703" y="6.5" width="57" height="57"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="7JA-pm-tBE" secondAttribute="height" id="ozb-N9-BDI"/>
                                         </constraints>
@@ -980,7 +1022,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="sEX-mf-IS6">
-                                        <rect key="frame" x="1003" y="5" width="12.5" height="13"/>
+                                        <rect key="frame" x="742.5" y="6.5" width="17" height="17.5"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1008,10 +1050,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z9M-tZ-0ow" userLabel="RedeemChildView">
-                                <rect key="frame" x="512" y="66" width="512" height="76.5"/>
+                                <rect key="frame" x="560.5" y="83.5" width="207.5" height="102.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hKb-o4-KzL">
-                                        <rect key="frame" x="0.0" y="14.5" width="512" height="48"/>
+                                        <rect key="frame" x="0.0" y="27.5" width="207.5" height="48"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                         <state key="normal" title="REDEEM">
                                             <color key="titleColor" red="0.1327331853" green="0.1327331853" blue="0.1327331853" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1030,10 +1072,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cdf-R2-2nF" userLabel="NotesView">
-                                <rect key="frame" x="0.0" y="496" width="1024" height="161.5"/>
+                                <rect key="frame" x="0.0" y="657" width="768" height="236"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Atq-bz-GnK">
-                                        <rect key="frame" x="51.5" y="8.5" width="921" height="145.5"/>
+                                        <rect key="frame" x="38.5" y="12" width="691" height="213"/>
                                         <color key="backgroundColor" white="1" alpha="0.5037992294520548" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -1062,6 +1104,7 @@
                             <constraint firstItem="GpQ-N3-WGT" firstAttribute="height" secondItem="dNn-bG-5ps" secondAttribute="height" multiplier="0.08" id="5ss-2C-F6d"/>
                             <constraint firstItem="Z9M-tZ-0ow" firstAttribute="width" secondItem="dNn-bG-5ps" secondAttribute="width" multiplier="0.5" id="BqR-3H-6DC"/>
                             <constraint firstItem="80r-pS-eBE" firstAttribute="top" secondItem="OXt-Dh-6lA" secondAttribute="bottom" id="Frc-nJ-pZ2"/>
+                            <constraint firstItem="Z9M-tZ-0ow" firstAttribute="width" secondItem="dNn-bG-5ps" secondAttribute="width" multiplier="0.27" id="H0W-MI-BnX"/>
                             <constraint firstItem="ftx-ku-Nrh" firstAttribute="top" secondItem="Z9M-tZ-0ow" secondAttribute="bottom" id="H3M-aD-fSK"/>
                             <constraint firstItem="oAR-Uz-Bxr" firstAttribute="trailing" secondItem="zIt-le-Adg" secondAttribute="trailing" id="H8k-2q-lyT"/>
                             <constraint firstItem="cdf-R2-2nF" firstAttribute="top" secondItem="80r-pS-eBE" secondAttribute="bottom" id="JGK-dd-kej"/>
@@ -1093,6 +1136,17 @@
                             <constraint firstItem="Z9M-tZ-0ow" firstAttribute="height" secondItem="dNn-bG-5ps" secondAttribute="height" multiplier="0.1" id="yij-D7-AyK"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="zIt-le-Adg"/>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="H0W-MI-BnX"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="BqR-3H-6DC"/>
+                                <include reference="H0W-MI-BnX"/>
+                            </mask>
+                        </variation>
                     </view>
                     <tabBarItem key="tabBarItem" title="Add Chore" image="iconAddChore_Sinactive" selectedImage="iconAddChore_S" id="0ie-jw-VkK"/>
                     <connections>
@@ -1123,18 +1177,18 @@
             <objects>
                 <viewController id="mZr-ny-ubW" customClass="SettingsViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Jc6-mS-8Ng" userLabel="SettingsContainerView">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="Bdz-f7-STD">
-                                <rect key="frame" x="0.0" y="-14.5" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="-14.5" width="768" height="1024"/>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WHX-r7-eV4" userLabel="CoinValView">
-                                <rect key="frame" x="0.0" y="74" width="491.5" height="69"/>
+                                <rect key="frame" x="0.0" y="91.5" width="368.5" height="92.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Coin Value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DZU-WR-vxO">
-                                        <rect key="frame" x="70.5" y="21.5" width="107.5" height="26.5"/>
+                                        <rect key="frame" x="70.5" y="33" width="107.5" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -1143,7 +1197,7 @@
                                         </variation>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vkd-0h-YKp">
-                                        <rect key="frame" x="353.5" y="19.5" width="122" height="30"/>
+                                        <rect key="frame" x="260.5" y="31.5" width="92" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
@@ -1152,7 +1206,7 @@
                                         </variation>
                                     </textField>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="coin" translatesAutoresizingMaskIntoConstraints="NO" id="IhS-43-o65">
-                                        <rect key="frame" x="16" y="12" width="46.5" height="46"/>
+                                        <rect key="frame" x="16" y="24" width="46.5" height="46"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="IhS-43-o65" secondAttribute="height" id="7AI-df-YZV"/>
                                         </constraints>
@@ -1210,10 +1264,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qrz-cb-a9A" userLabel="BonusDayView">
-                                <rect key="frame" x="0.0" y="143" width="491.5" height="69"/>
+                                <rect key="frame" x="0.0" y="184" width="368.5" height="92.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bonus Day:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vww-Fn-Ya1">
-                                        <rect key="frame" x="16" y="21" width="109" height="26.5"/>
+                                        <rect key="frame" x="16" y="33" width="109" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -1222,7 +1276,7 @@
                                         </variation>
                                     </label>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Wr-Ni-72u">
-                                        <rect key="frame" x="426.5" y="18.5" width="51" height="31"/>
+                                        <rect key="frame" x="303.5" y="30.5" width="51" height="31"/>
                                         <connections>
                                             <action selector="toggleBonusDay:" destination="mZr-ny-ubW" eventType="valueChanged" id="aSb-a8-beP"/>
                                         </connections>
@@ -1263,10 +1317,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S1r-fj-3AW" userLabel="BonusMultView">
-                                <rect key="frame" x="0.0" y="212" width="491.5" height="69"/>
+                                <rect key="frame" x="0.0" y="276.5" width="368.5" height="92.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bonus Multiplier Value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jez-eq-ibE">
-                                        <rect key="frame" x="16" y="22" width="216.5" height="26.5"/>
+                                        <rect key="frame" x="16" y="33.5" width="216.5" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -1275,7 +1329,7 @@
                                         </variation>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="TYh-2W-UqW">
-                                        <rect key="frame" x="353.5" y="20" width="122" height="30"/>
+                                        <rect key="frame" x="260.5" y="31.5" width="92" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
@@ -1324,13 +1378,13 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cyh-IY-4J2" userLabel="HeaderView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="54"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="vMq-Q1-bDA">
-                                        <rect key="frame" x="0.0" y="0.0" width="1024" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="71.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5FP-4v-sSN">
-                                        <rect key="frame" x="8" y="8" width="37" height="37"/>
+                                        <rect key="frame" x="8" y="10.5" width="49.5" height="49.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="5FP-4v-sSN" secondAttribute="height" id="xf3-qG-eFI"/>
                                         </constraints>
@@ -1340,7 +1394,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Lo-So-qYU">
-                                        <rect key="frame" x="53" y="12" width="120" height="30"/>
+                                        <rect key="frame" x="65.5" y="21" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1349,7 +1403,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JhJ-k8-sPy">
-                                        <rect key="frame" x="948" y="12" width="17" height="30"/>
+                                        <rect key="frame" x="678" y="20" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1358,7 +1412,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vCf-mM-Gx1" userLabel="CoinButton">
-                                        <rect key="frame" x="973" y="5" width="43" height="42.5"/>
+                                        <rect key="frame" x="703" y="6.5" width="57" height="57"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="vCf-mM-Gx1" secondAttribute="height" id="IBG-Ar-BmW"/>
                                         </constraints>
@@ -1368,7 +1422,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="DLb-fP-r5j">
-                                        <rect key="frame" x="1003" y="5" width="13" height="13"/>
+                                        <rect key="frame" x="742.5" y="6.5" width="17.5" height="17.5"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1396,10 +1450,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QX8-QA-bRk" userLabel="BackgroundView">
-                                <rect key="frame" x="532.5" y="74" width="491.5" height="679.5"/>
+                                <rect key="frame" x="399.5" y="91.5" width="368.5" height="932.5"/>
                                 <subviews>
                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YRZ-tG-oLd" userLabel="purpBG">
-                                        <rect key="frame" x="27" y="521" width="435" height="67"/>
+                                        <rect key="frame" x="22" y="652" width="324.5" height="92.5"/>
                                         <state key="normal" backgroundImage="purpleBG"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
@@ -1411,7 +1465,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Swc-cu-kWe" userLabel="RedBG">
-                                        <rect key="frame" x="27" y="414.5" width="435" height="67.5"/>
+                                        <rect key="frame" x="22" y="511.5" width="324.5" height="92.5"/>
                                         <state key="normal" backgroundImage="redBG"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
@@ -1423,7 +1477,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uFd-uJ-5wa" userLabel="greenBG">
-                                        <rect key="frame" x="27" y="309.5" width="435" height="67.5"/>
+                                        <rect key="frame" x="22" y="372" width="324.5" height="93"/>
                                         <state key="normal" backgroundImage="greenBG"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
@@ -1435,7 +1489,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Op-zc-pkM" userLabel="orangeBG">
-                                        <rect key="frame" x="27" y="208.5" width="435" height="68"/>
+                                        <rect key="frame" x="22" y="239" width="324.5" height="93"/>
                                         <state key="normal" backgroundImage="orangeBG"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
@@ -1447,7 +1501,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Background:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kYe-5c-8pj">
-                                        <rect key="frame" x="8" y="16" width="483.5" height="26.5"/>
+                                        <rect key="frame" x="8" y="16" width="360.5" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -1456,7 +1510,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oGY-Mv-jcJ" userLabel="whiteBG">
-                                        <rect key="frame" x="27" y="106.5" width="435" height="67.5"/>
+                                        <rect key="frame" x="22" y="106.5" width="324.5" height="93"/>
                                         <state key="normal" backgroundImage="whiteBG"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
@@ -1596,10 +1650,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZoU-8u-V6T" userLabel="RedeemChildView">
-                                <rect key="frame" x="747.5" y="66" width="276.5" height="76.5"/>
+                                <rect key="frame" x="560.5" y="83.5" width="207.5" height="102.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jBy-LU-GrE">
-                                        <rect key="frame" x="0.0" y="14.5" width="276.5" height="48"/>
+                                        <rect key="frame" x="0.0" y="27.5" width="207.5" height="48"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                         <state key="normal" title="REDEEM">
                                             <color key="titleColor" red="0.1327331853" green="0.1327331853" blue="0.1327331853" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1622,24 +1676,24 @@
                         <constraints>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="top" secondItem="cyh-IY-4J2" secondAttribute="bottom" id="0fc-uc-2PV"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="1JA-vU-Bpt"/>
+                            <constraint firstItem="QX8-QA-bRk" firstAttribute="width" secondItem="p7V-lx-juA" secondAttribute="width" id="23W-oj-eia"/>
                             <constraint firstItem="p7V-lx-juA" firstAttribute="trailing" secondItem="QX8-QA-bRk" secondAttribute="trailing" id="3B4-Fo-Eqi"/>
-                            <constraint firstItem="QX8-QA-bRk" firstAttribute="top" secondItem="cyh-IY-4J2" secondAttribute="bottom" id="3Q7-in-cVq"/>
                             <constraint firstItem="S1r-fj-3AW" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="3Uk-7y-5o0"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="width" secondItem="WHX-r7-eV4" secondAttribute="width" id="9rK-cg-M0a"/>
                             <constraint firstItem="p7V-lx-juA" firstAttribute="trailing" secondItem="ZoU-8u-V6T" secondAttribute="trailing" id="Acg-ku-npo"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="height" secondItem="WHX-r7-eV4" secondAttribute="height" id="AeW-1e-ZWh"/>
                             <constraint firstItem="QX8-QA-bRk" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="AtM-Qg-vQ9"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="top" secondItem="WHX-r7-eV4" secondAttribute="bottom" id="B04-VX-vRa"/>
+                            <constraint firstItem="QX8-QA-bRk" firstAttribute="top" secondItem="cyh-IY-4J2" secondAttribute="bottom" id="BIr-fr-dQG"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="width" secondItem="Jc6-mS-8Ng" secondAttribute="width" multiplier="0.48" id="C3T-KG-G9E"/>
                             <constraint firstItem="p7V-lx-juA" firstAttribute="trailing" secondItem="WHX-r7-eV4" secondAttribute="trailing" id="Cup-7y-TRd"/>
                             <constraint firstItem="S1r-fj-3AW" firstAttribute="top" secondItem="Qrz-cb-a9A" secondAttribute="bottom" id="EIw-z6-PRy"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.08" id="FPs-Dh-qvb"/>
                             <constraint firstItem="QX8-QA-bRk" firstAttribute="top" secondItem="S1r-fj-3AW" secondAttribute="bottom" id="FSb-Hb-Jys"/>
                             <constraint firstItem="ZoU-8u-V6T" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.1" id="GbO-9i-wNb"/>
+                            <constraint firstItem="QX8-QA-bRk" firstAttribute="width" secondItem="Jc6-mS-8Ng" secondAttribute="width" multiplier="0.48" id="Gz9-BI-YzP"/>
                             <constraint firstItem="ZoU-8u-V6T" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.1" id="Kfn-UI-2WL"/>
-                            <constraint firstItem="QX8-QA-bRk" firstAttribute="width" secondItem="Bdz-f7-STD" secondAttribute="width" multiplier="0.48" id="LR4-Vv-Uke"/>
                             <constraint firstItem="p7V-lx-juA" firstAttribute="trailing" secondItem="Qrz-cb-a9A" secondAttribute="trailing" id="N7W-KE-DJa"/>
-                            <constraint firstItem="QX8-QA-bRk" firstAttribute="trailing" secondItem="Bdz-f7-STD" secondAttribute="trailing" id="NGD-re-xMV"/>
                             <constraint firstItem="ZoU-8u-V6T" firstAttribute="width" secondItem="Jc6-mS-8Ng" secondAttribute="width" multiplier="0.27" id="Ne8-0l-bd0"/>
                             <constraint firstItem="S1r-fj-3AW" firstAttribute="height" secondItem="Qrz-cb-a9A" secondAttribute="height" id="NzU-JJ-u60"/>
                             <constraint firstItem="Bdz-f7-STD" firstAttribute="centerX" secondItem="p7V-lx-juA" secondAttribute="centerX" id="PlB-oW-oeZ"/>
@@ -1648,6 +1702,7 @@
                             <constraint firstItem="p7V-lx-juA" firstAttribute="bottom" secondItem="QX8-QA-bRk" secondAttribute="bottom" id="SwM-Cd-3is"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="trailing" secondItem="p7V-lx-juA" secondAttribute="trailing" id="TtW-T5-I3j"/>
                             <constraint firstItem="Bdz-f7-STD" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" id="WB1-lA-uYP"/>
+                            <constraint firstItem="QX8-QA-bRk" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="XLb-gf-say"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="civ-3y-YA0"/>
                             <constraint firstItem="cyh-IY-4J2" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.07" id="dNA-bS-LW4"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="eC3-j5-6yp"/>
@@ -1658,21 +1713,28 @@
                             <constraint firstItem="S1r-fj-3AW" firstAttribute="top" secondItem="Qrz-cb-a9A" secondAttribute="bottom" id="j7b-qe-L9a"/>
                             <constraint firstItem="ZoU-8u-V6T" firstAttribute="top" secondItem="vMq-Q1-bDA" secondAttribute="bottom" constant="-8" id="jX9-6J-9ss"/>
                             <constraint firstItem="Bdz-f7-STD" firstAttribute="width" secondItem="Jc6-mS-8Ng" secondAttribute="width" id="lIH-Aw-nRw"/>
+                            <constraint firstItem="QX8-QA-bRk" firstAttribute="trailing" secondItem="p7V-lx-juA" secondAttribute="trailing" id="mE2-OZ-vcK"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.09" id="mWD-NP-dC5"/>
                             <constraint firstItem="cyh-IY-4J2" firstAttribute="trailing" secondItem="p7V-lx-juA" secondAttribute="trailing" id="nwP-b5-i6M"/>
                             <constraint firstItem="p7V-lx-juA" firstAttribute="trailing" secondItem="S1r-fj-3AW" secondAttribute="trailing" id="qX2-4X-kxE"/>
-                            <constraint firstItem="QX8-QA-bRk" firstAttribute="bottom" secondItem="Bdz-f7-STD" secondAttribute="bottom" id="rDg-u3-wRn"/>
                             <constraint firstItem="Qrz-cb-a9A" firstAttribute="top" secondItem="WHX-r7-eV4" secondAttribute="bottom" id="rLc-u4-TA7"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.08" id="sbv-4r-vLD"/>
                             <constraint firstItem="S1r-fj-3AW" firstAttribute="width" secondItem="Qrz-cb-a9A" secondAttribute="width" id="shb-41-ma7"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="leading" secondItem="p7V-lx-juA" secondAttribute="leading" id="uoa-Pt-3y3"/>
                             <constraint firstItem="ZoU-8u-V6T" firstAttribute="width" secondItem="Jc6-mS-8Ng" secondAttribute="width" multiplier="0.48" id="vFm-vv-pgZ"/>
+                            <constraint firstAttribute="bottom" secondItem="QX8-QA-bRk" secondAttribute="bottom" id="xGr-bz-zwj"/>
                             <constraint firstItem="S1r-fj-3AW" firstAttribute="height" secondItem="Jc6-mS-8Ng" secondAttribute="height" multiplier="0.08" id="xMO-Vh-5Gy"/>
                             <constraint firstItem="WHX-r7-eV4" firstAttribute="top" secondItem="cyh-IY-4J2" secondAttribute="bottom" id="zVN-8b-hF7"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="p7V-lx-juA"/>
                         <variation key="default">
                             <mask key="constraints">
+                                <exclude reference="23W-oj-eia"/>
+                                <exclude reference="BIr-fr-dQG"/>
+                                <exclude reference="Gz9-BI-YzP"/>
+                                <exclude reference="XLb-gf-say"/>
+                                <exclude reference="mE2-OZ-vcK"/>
+                                <exclude reference="xGr-bz-zwj"/>
                                 <exclude reference="0fc-uc-2PV"/>
                                 <exclude reference="C3T-KG-G9E"/>
                                 <exclude reference="RaF-Ne-RHt"/>
@@ -1685,10 +1747,6 @@
                                 <exclude reference="iOi-dc-ZsD"/>
                                 <exclude reference="j7b-qe-L9a"/>
                                 <exclude reference="shb-41-ma7"/>
-                                <exclude reference="3Q7-in-cVq"/>
-                                <exclude reference="LR4-Vv-Uke"/>
-                                <exclude reference="NGD-re-xMV"/>
-                                <exclude reference="rDg-u3-wRn"/>
                                 <exclude reference="GbO-9i-wNb"/>
                                 <exclude reference="Ne8-0l-bd0"/>
                                 <exclude reference="iEi-Sc-ruO"/>
@@ -1701,6 +1759,12 @@
                                 <exclude reference="N7W-KE-DJa"/>
                                 <exclude reference="SwM-Cd-3is"/>
                                 <exclude reference="qX2-4X-kxE"/>
+                                <exclude reference="AtM-Qg-vQ9"/>
+                                <include reference="BIr-fr-dQG"/>
+                                <exclude reference="FSb-Hb-Jys"/>
+                                <include reference="Gz9-BI-YzP"/>
+                                <include reference="mE2-OZ-vcK"/>
+                                <include reference="xGr-bz-zwj"/>
                                 <include reference="0fc-uc-2PV"/>
                                 <include reference="C3T-KG-G9E"/>
                                 <include reference="RaF-Ne-RHt"/>
@@ -1724,12 +1788,6 @@
                                 <include reference="j7b-qe-L9a"/>
                                 <include reference="shb-41-ma7"/>
                                 <exclude reference="xMO-Vh-5Gy"/>
-                                <include reference="3Q7-in-cVq"/>
-                                <exclude reference="AtM-Qg-vQ9"/>
-                                <exclude reference="FSb-Hb-Jys"/>
-                                <include reference="LR4-Vv-Uke"/>
-                                <include reference="NGD-re-xMV"/>
-                                <include reference="rDg-u3-wRn"/>
                                 <include reference="GbO-9i-wNb"/>
                                 <exclude reference="Kfn-UI-2WL"/>
                                 <include reference="Ne8-0l-bd0"/>
@@ -1742,18 +1800,20 @@
                     <tabBarItem key="tabBarItem" title="Settings" image="iconSettings_Sinactive" selectedImage="iconSettings_S" id="c1J-oS-J4D"/>
                     <connections>
                         <outlet property="BonusMultView" destination="S1r-fj-3AW" id="Ica-X0-pE1"/>
+                        <outlet property="backgroundView" destination="QX8-QA-bRk" id="0pC-QX-RGg"/>
+                        <outlet property="backgroundWidthSafeiPad" destination="23W-oj-eia" id="z7J-RO-ie4"/>
+                        <outlet property="backgroundWidthSuperiPad" destination="Gz9-BI-YzP" id="exJ-At-Ju8"/>
                         <outlet property="bgImage" destination="Bdz-f7-STD" id="lGS-x4-slJ"/>
                         <outlet property="bonusDaySwitch" destination="4Wr-Ni-72u" id="b2e-Tg-Y67"/>
                         <outlet property="bonusDayView" destination="Qrz-cb-a9A" id="boX-QB-qYB"/>
                         <outlet property="childRedeemView" destination="ZoU-8u-V6T" id="35w-le-gqE"/>
                         <outlet property="coinAmtLabel" destination="JhJ-k8-sPy" id="leh-E8-Fc6"/>
-                        <outlet property="coinValHeight" destination="sbv-4r-vLD" id="6UY-3R-lIq"/>
-                        <outlet property="coinValHeightiPad" destination="mWD-NP-dC5" id="D14-Od-WbE"/>
                         <outlet property="coinValView" destination="WHX-r7-eV4" id="jlC-AA-Cof"/>
                         <outlet property="coinValueTextField" destination="vkd-0h-YKp" id="MuV-zw-Grb"/>
                         <outlet property="multiplierValueTextField" destination="TYh-2W-UqW" id="ysu-bm-sYd"/>
                         <outlet property="profileButton" destination="5FP-4v-sSN" id="TxS-h3-PLG"/>
                         <outlet property="redDot" destination="DLb-fP-r5j" id="BcF-ef-vLt"/>
+                        <outlet property="settingsSuperView" destination="Jc6-mS-8Ng" id="5zm-pI-9kk"/>
                         <outlet property="usernameLabel" destination="7Lo-So-qYU" id="so5-3m-dFg"/>
                         <segue destination="q0I-az-h0x" kind="presentation" identifier="toCoinFromSettings" id="TW0-XL-iud"/>
                     </connections>
@@ -1767,20 +1827,20 @@
             <objects>
                 <viewController id="q0I-az-h0x" customClass="ParentCoinChildViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="y30-AZ-gPy">
-                        <rect key="frame" x="0.0" y="0.0" width="703" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="zb2-Te-N3z">
-                                <rect key="frame" x="0.0" y="10" width="703" height="645"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i9q-7L-CW2" userLabel="CalcTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="703" height="45"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="T9m-Pq-0cd">
-                                        <rect key="frame" x="0.0" y="0.0" width="703" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="71.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9tR-Sh-fGg">
-                                        <rect key="frame" x="8" y="6.5" width="31.5" height="31.5"/>
+                                        <rect key="frame" x="8" y="10.5" width="50.5" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="9tR-Sh-fGg" secondAttribute="height" id="y4F-yu-eRY"/>
                                         </constraints>
@@ -1790,7 +1850,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w2p-xC-m4m">
-                                        <rect key="frame" x="47.5" y="6.5" width="120" height="30"/>
+                                        <rect key="frame" x="66.5" y="20" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1799,7 +1859,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZVM-2r-Tl5">
-                                        <rect key="frame" x="635" y="6.5" width="17" height="30"/>
+                                        <rect key="frame" x="678" y="20" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1808,14 +1868,14 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HKB-qb-kkX">
-                                        <rect key="frame" x="660" y="4" width="35" height="35.5"/>
+                                        <rect key="frame" x="703" y="6.5" width="57" height="57"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="HKB-qb-kkX" secondAttribute="height" id="Ck3-PJ-M6q"/>
                                         </constraints>
                                         <state key="normal" backgroundImage="coin"/>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="ba4-GO-3ZK">
-                                        <rect key="frame" x="684" y="4" width="11" height="11"/>
+                                        <rect key="frame" x="742.5" y="6.5" width="17.5" height="17.5"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1843,21 +1903,21 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iEl-Tc-OPg">
-                                <rect key="frame" x="8" y="65" width="48" height="30"/>
+                                <rect key="frame" x="8" y="91.5" width="48" height="30"/>
                                 <state key="normal" title="&lt; Back"/>
                                 <connections>
                                     <action selector="dismissView:" destination="q0I-az-h0x" eventType="touchUpInside" id="jU7-hv-16E"/>
                                 </connections>
                             </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lh4-Wd-uEi">
-                                <rect key="frame" x="0.0" y="95" width="703" height="550"/>
+                                <rect key="frame" x="0.0" y="121.5" width="768" height="902.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="leP-16-6Qr" detailTextLabel="Kyi-vo-c9U" style="IBUITableViewCellStyleValue1" id="Saf-ke-Dy6">
-                                        <rect key="frame" x="0.0" y="28" width="703" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="768" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Saf-ke-Dy6" id="gau-3L-vRk">
-                                            <rect key="frame" x="0.0" y="0.0" width="703" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="768" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="leP-16-6Qr">
@@ -1868,7 +1928,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kyi-vo-c9U">
-                                                    <rect key="frame" x="644" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="709" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1922,20 +1982,20 @@
             <objects>
                 <viewController id="QtQ-q5-P19" customClass="AddRemoveCoinsViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="0Yd-Og-B5I">
-                        <rect key="frame" x="0.0" y="0.0" width="703" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="L9c-rq-7lY">
-                                <rect key="frame" x="0.5" y="10" width="703" height="645"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1rv-C9-vng" userLabel="CalcTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="703" height="45"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="Jhs-MH-nD0">
-                                        <rect key="frame" x="0.0" y="0.0" width="703" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="71.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="317-aF-8fj">
-                                        <rect key="frame" x="8" y="6.5" width="31" height="31"/>
+                                        <rect key="frame" x="8" y="10.5" width="49.5" height="49.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="317-aF-8fj" secondAttribute="height" id="KS8-QV-3gg"/>
                                         </constraints>
@@ -1945,7 +2005,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GbC-Hw-56e">
-                                        <rect key="frame" x="47" y="6.5" width="120" height="30"/>
+                                        <rect key="frame" x="65.5" y="20" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1954,7 +2014,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fny-wj-t1c">
-                                        <rect key="frame" x="633.5" y="6.5" width="17" height="30"/>
+                                        <rect key="frame" x="677.5" y="20" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1963,14 +2023,14 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BsF-QA-LAY">
-                                        <rect key="frame" x="658.5" y="4" width="36.5" height="36.5"/>
+                                        <rect key="frame" x="702.5" y="7" width="57.5" height="57"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="BsF-QA-LAY" secondAttribute="height" id="FdZ-ZF-QPr"/>
                                         </constraints>
                                         <state key="normal" backgroundImage="coin"/>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="TAW-WM-THD">
-                                        <rect key="frame" x="684" y="4" width="11" height="11"/>
+                                        <rect key="frame" x="743" y="7" width="17" height="17"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1998,10 +2058,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="og5-9K-VUR" userLabel="CoinTotalNumbersView">
-                                <rect key="frame" x="0.0" y="117" width="703" height="129"/>
+                                <rect key="frame" x="0.0" y="173.5" width="768" height="205"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sId-TV-pES">
-                                        <rect key="frame" x="50" y="29.5" width="70" height="70.5"/>
+                                        <rect key="frame" x="50" y="64.5" width="76.5" height="77"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="sId-TV-pES" secondAttribute="height" id="uEc-lu-XBj"/>
                                         </constraints>
@@ -2011,7 +2071,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BB1-53-g0D">
-                                        <rect key="frame" x="583" y="29.5" width="70" height="70"/>
+                                        <rect key="frame" x="641.5" y="64.5" width="76.5" height="77"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="BB1-53-g0D" secondAttribute="height" id="Lg4-2n-zsD"/>
                                         </constraints>
@@ -2021,7 +2081,7 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="l4I-pq-XSk">
-                                        <rect key="frame" x="136" y="16.5" width="431" height="97"/>
+                                        <rect key="frame" x="142.5" y="16" width="483" height="173"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="80"/>
                                         <textInputTraits key="textInputTraits" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
@@ -2058,10 +2118,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="71M-lG-bJq" userLabel="CalcRedeemDoneView">
-                                <rect key="frame" x="0.0" y="548.5" width="703" height="96.5"/>
+                                <rect key="frame" x="0.0" y="870.5" width="768" height="153.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lpR-F0-FE5">
-                                        <rect key="frame" x="37" y="29.5" width="293.5" height="38"/>
+                                        <rect key="frame" x="39" y="46" width="322" height="62"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="REDEEM" backgroundImage="btnOrange_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2071,11 +2131,11 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mKB-OV-8bi">
-                                        <rect key="frame" x="330.5" y="0.5" width="42" height="97"/>
+                                        <rect key="frame" x="361" y="0.5" width="46" height="153.5"/>
                                         <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A5a-HG-2IF">
-                                        <rect key="frame" x="372.5" y="29.5" width="293.5" height="38"/>
+                                        <rect key="frame" x="407" y="46" width="322" height="62"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="DONE" backgroundImage="btnOrange_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2085,7 +2145,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="RJ2-lw-Ey6">
-                                        <rect key="frame" x="323" y="25.5" width="11.5" height="11"/>
+                                        <rect key="frame" x="346" y="42" width="19" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="RJ2-lw-Ey6" secondAttribute="height" multiplier="1:1" id="D14-Sm-18D"/>
                                         </constraints>
@@ -2113,10 +2173,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ebp-63-l6S">
-                                <rect key="frame" x="0.0" y="65" width="703" height="52"/>
+                                <rect key="frame" x="0.0" y="91.5" width="768" height="82"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Child Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.25" translatesAutoresizingMaskIntoConstraints="NO" id="U2Q-Zg-8se">
-                                        <rect key="frame" x="-0.5" y="17" width="703" height="30"/>
+                                        <rect key="frame" x="-0.5" y="35" width="768" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -2180,17 +2240,17 @@
             <objects>
                 <viewController id="b6P-mi-Mj5" customClass="SignUpParentChildViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="fIK-A9-fZn">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="bUi-qG-dO7">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f0I-Qy-M1b" userLabel="CreateAccountLogoView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="384"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="512"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo_L" translatesAutoresizingMaskIntoConstraints="NO" id="9fB-ep-4Y6">
-                                        <rect key="frame" x="103" y="51.5" width="819" height="281"/>
+                                        <rect key="frame" x="77.5" y="115.5" width="614" height="281"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2201,10 +2261,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m77-hq-huN" userLabel="CreateAccountButtonsView">
-                                <rect key="frame" x="0.0" y="404" width="1024" height="364"/>
+                                <rect key="frame" x="0.0" y="532" width="768" height="492"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="20n-jf-kag">
-                                        <rect key="frame" x="351.5" y="155" width="322" height="54.5"/>
+                                        <rect key="frame" x="223.5" y="209.5" width="322" height="73.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="SIGN IN" backgroundImage="btnGray_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2213,8 +2273,8 @@
                                             <action selector="signInOrRegister:" destination="b6P-mi-Mj5" eventType="touchUpInside" id="fJL-Oq-6K6"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zN6-s4-7wV">
-                                        <rect key="frame" x="975" y="326" width="33" height="30"/>
+                                    <button hidden="YES" opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zN6-s4-7wV">
+                                        <rect key="frame" x="719" y="454" width="33" height="30"/>
                                         <state key="normal" title="SKIP"/>
                                         <connections>
                                             <action selector="skipRegistration:" destination="b6P-mi-Mj5" eventType="touchUpInside" id="6ec-xk-fcG"/>
@@ -2281,17 +2341,17 @@
             <objects>
                 <viewController storyboardIdentifier="parentChildVC" id="H6A-gN-jhU" customClass="ParentChildViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Fpa-gM-mgg">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="rwr-C7-tte">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oFM-MG-BCs" userLabel="CreateAccountButtonsView">
-                                <rect key="frame" x="0.0" y="404.5" width="1024" height="363.5"/>
+                                <rect key="frame" x="0.0" y="532.5" width="768" height="491.5"/>
                                 <subviews>
                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hOf-AC-Iyl">
-                                        <rect key="frame" x="351.5" y="154.5" width="322" height="54.5"/>
+                                        <rect key="frame" x="223.5" y="209" width="322" height="73.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="CREATE CHILD ACCOUNT" backgroundImage="btnRed_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2302,7 +2362,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bfl-d4-rhV">
-                                        <rect key="frame" x="351" y="69.5" width="322" height="54.5"/>
+                                        <rect key="frame" x="223" y="94" width="322" height="73.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="CREATE PARENT ACCOUNT" backgroundImage="btnOrange_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2332,10 +2392,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Eq-K9-EzS" userLabel="CreateAccountLogoView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="384"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="512"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo_L" translatesAutoresizingMaskIntoConstraints="NO" id="d9z-Sy-XoK">
-                                        <rect key="frame" x="103" y="52" width="819" height="281"/>
+                                        <rect key="frame" x="77.5" y="116" width="614" height="281"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2390,11 +2450,11 @@
             <objects>
                 <viewController id="zGP-ut-peX" customClass="CreateAccountViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="VTj-CL-PhU">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="ui3-Ev-fFt">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b5k-nj-J2G">
                                 <rect key="frame" x="8" y="20" width="48" height="30"/>
@@ -2404,10 +2464,10 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aet-ak-hSa" userLabel="ProfilePicView">
-                                <rect key="frame" x="0.0" y="50" width="1024" height="292"/>
+                                <rect key="frame" x="0.0" y="50" width="768" height="389"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QYm-ZM-XWR">
-                                        <rect key="frame" x="394.5" y="28.5" width="236" height="236.5"/>
+                                        <rect key="frame" x="192.5" y="3" width="384" height="384.5"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="QYm-ZM-XWR" secondAttribute="height" id="IsF-S6-1xc"/>
                                         </constraints>
@@ -2430,41 +2490,41 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rk2-oa-8dX" userLabel="CreateProfileView">
-                                <rect key="frame" x="0.0" y="342" width="1024" height="272.5"/>
+                                <rect key="frame" x="0.0" y="439" width="768" height="380"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pHx-5I-TLJ">
-                                        <rect key="frame" x="256" y="58.5" width="512" height="30"/>
+                                        <rect key="frame" x="192" y="97.5" width="384" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jqV-Vu-bKP">
-                                        <rect key="frame" x="256" y="141.5" width="512" height="30"/>
+                                        <rect key="frame" x="192" y="203.5" width="384" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Generated Parent ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cR1-hV-gCj">
-                                        <rect key="frame" x="256" y="229" width="512" height="30"/>
+                                        <rect key="frame" x="192" y="311.5" width="384" height="30"/>
                                         <accessibility key="accessibilityConfiguration" hint="parent ID"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MGA-2B-teT">
-                                        <rect key="frame" x="256" y="33.5" width="512" height="17"/>
+                                        <rect key="frame" x="192" y="72.5" width="384" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ml1-Fs-2Bx">
-                                        <rect key="frame" x="256" y="116.5" width="512" height="17"/>
+                                        <rect key="frame" x="192" y="178.5" width="384" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parent ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QyP-RK-nFi">
-                                        <rect key="frame" x="256" y="204" width="512" height="17"/>
+                                        <rect key="frame" x="192" y="286.5" width="384" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -2505,10 +2565,10 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cxp-x4-QFQ" userLabel="CreateAccountButtonView">
-                                <rect key="frame" x="0.0" y="614.5" width="1024" height="153.5"/>
+                                <rect key="frame" x="0.0" y="819" width="768" height="205"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S88-Kh-cOE">
-                                        <rect key="frame" x="350.5" y="54" width="322" height="45.5"/>
+                                        <rect key="frame" x="222.5" y="72" width="322" height="61"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="CREATE ACCOUNT" backgroundImage="btnOrange_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2550,7 +2610,7 @@
                             <constraint firstItem="ui3-Ev-fFt" firstAttribute="centerX" secondItem="9yw-8x-uQq" secondAttribute="centerX" id="jZ0-7H-Hte"/>
                             <constraint firstItem="cxp-x4-QFQ" firstAttribute="height" secondItem="VTj-CL-PhU" secondAttribute="height" multiplier="0.2" id="l23-Zd-idQ"/>
                             <constraint firstItem="9yw-8x-uQq" firstAttribute="trailing" secondItem="Rk2-oa-8dX" secondAttribute="trailing" id="osI-zi-0I5"/>
-                            <constraint firstItem="QYm-ZM-XWR" firstAttribute="width" secondItem="VTj-CL-PhU" secondAttribute="width" multiplier="0.23" id="tgx-y7-chD"/>
+                            <constraint firstItem="QYm-ZM-XWR" firstAttribute="width" secondItem="VTj-CL-PhU" secondAttribute="width" multiplier="0.5" id="tgx-y7-chD"/>
                             <constraint firstItem="9yw-8x-uQq" firstAttribute="bottom" secondItem="cxp-x4-QFQ" secondAttribute="bottom" id="thE-AQ-Q5e"/>
                             <constraint firstItem="9yw-8x-uQq" firstAttribute="trailing" secondItem="aet-ak-hSa" secondAttribute="trailing" id="thg-7U-PdR"/>
                             <constraint firstItem="aet-ak-hSa" firstAttribute="top" secondItem="b5k-nj-J2G" secondAttribute="bottom" id="zFS-xh-kyu"/>
@@ -2584,11 +2644,11 @@
             <objects>
                 <viewController id="ABl-CU-dru" customClass="ProfilePictureSelectViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Znu-ep-Yit">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="D7y-x7-b3M">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="768"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="1024"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GwG-GB-J2U">
                                 <rect key="frame" x="8" y="20" width="48" height="30"/>
@@ -2598,19 +2658,19 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CHOOSE A PROFILE PICTURE" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W1T-mY-3ae">
-                                <rect key="frame" x="0.0" y="80" width="1024" height="30"/>
+                                <rect key="frame" x="0.0" y="80" width="768" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nnD-oN-RFt" userLabel="ProfilePicSelectView">
-                                <rect key="frame" x="8" y="145.5" width="1008" height="614.5"/>
+                                <rect key="frame" x="8" y="197" width="752" height="819"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PxT-4M-s71" userLabel="Button1_2View">
-                                        <rect key="frame" x="0.0" y="0.0" width="378" height="614.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="282" height="819"/>
                                         <subviews>
                                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YdZ-aJ-6gx">
-                                                <rect key="frame" x="50.5" y="308.5" width="252" height="252"/>
+                                                <rect key="frame" x="38" y="405.5" width="187.5" height="187.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="YdZ-aJ-6gx" secondAttribute="height" id="cTH-QD-WoZ"/>
                                                 </constraints>
@@ -2620,7 +2680,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4XA-bb-e6z">
-                                                <rect key="frame" x="50.5" y="24.5" width="252" height="252"/>
+                                                <rect key="frame" x="38" y="186" width="187.5" height="187.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="4XA-bb-e6z" secondAttribute="height" id="fw2-Di-Bla"/>
                                                 </constraints>
@@ -2630,7 +2690,7 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wat-T0-XIs" userLabel="Spacer">
-                                                <rect key="frame" x="0.0" y="0.0" width="50.5" height="614.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="38" height="819"/>
                                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                         </subviews>
@@ -2685,10 +2745,10 @@
                                         </variation>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OUk-yO-6Cn" userLabel="Button5_6View">
-                                        <rect key="frame" x="630" y="0.0" width="378" height="614.5"/>
+                                        <rect key="frame" x="470" y="0.0" width="282" height="819"/>
                                         <subviews>
                                             <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ha-R6-uJI">
-                                                <rect key="frame" x="62.5" y="308.5" width="252" height="251.5"/>
+                                                <rect key="frame" x="47" y="405.5" width="188" height="187.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="1ha-R6-uJI" secondAttribute="height" id="018-oD-pbD"/>
                                                 </constraints>
@@ -2698,7 +2758,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KIk-a7-ROT">
-                                                <rect key="frame" x="63" y="25" width="251.5" height="251.5"/>
+                                                <rect key="frame" x="47" y="186" width="187.5" height="187.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="KIk-a7-ROT" secondAttribute="height" id="7vh-q3-Tk2"/>
                                                 </constraints>
@@ -2708,7 +2768,7 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dpv-lR-ZBx" userLabel="Spacer">
-                                                <rect key="frame" x="314.5" y="0.0" width="63.5" height="614.5"/>
+                                                <rect key="frame" x="234.5" y="0.0" width="47.5" height="819"/>
                                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                         </subviews>
@@ -2760,10 +2820,10 @@
                                         </variation>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0E2-HG-l4w" userLabel="Button3_4View">
-                                        <rect key="frame" x="378" y="0.0" width="252" height="614.5"/>
+                                        <rect key="frame" x="282" y="0.0" width="188" height="819"/>
                                         <subviews>
                                             <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nW3-dW-wPO">
-                                                <rect key="frame" x="0.0" y="25" width="252" height="251.5"/>
+                                                <rect key="frame" x="0.0" y="186" width="188" height="187.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="nW3-dW-wPO" secondAttribute="height" id="PJe-eA-3S7"/>
                                                 </constraints>
@@ -2773,7 +2833,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Ro-X4-hdc">
-                                                <rect key="frame" x="0.0" y="308.5" width="252" height="251.5"/>
+                                                <rect key="frame" x="0.0" y="405.5" width="188" height="187.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="4Ro-X4-hdc" secondAttribute="height" id="82h-8P-Q3p"/>
                                                 </constraints>
@@ -2783,7 +2843,7 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j8J-X3-cP0" userLabel="Spacer">
-                                                <rect key="frame" x="0.0" y="292.5" width="252" height="30.5"/>
+                                                <rect key="frame" x="0.0" y="389.5" width="188" height="41"/>
                                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                         </subviews>
@@ -2950,7 +3010,7 @@
                                 </variation>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bok-QF-QLQ">
-                                <rect key="frame" x="931" y="20" width="85" height="30"/>
+                                <rect key="frame" x="675" y="20" width="85" height="30"/>
                                 <state key="normal" title="Take Picture">
                                     <color key="titleColor" name="CFCDarkBlue"/>
                                 </state>
@@ -3020,419 +3080,22 @@
             </objects>
             <point key="canvasLocation" x="-830" y="207"/>
         </scene>
-        <!--Chore Details View Controller-->
-        <scene sceneID="fSk-kw-XAA">
-            <objects>
-                <viewController storyboardIdentifier="choreDetails" id="6dG-q3-qFR" customClass="ChoreDetailsViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="OZG-HX-J5A">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="FHk-kR-gff">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="768"/>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bSq-U0-DY5">
-                                <rect key="frame" x="986" y="74" width="30" height="30"/>
-                                <state key="normal" title="Edit"/>
-                                <connections>
-                                    <action selector="editChoreBtn:" destination="6dG-q3-qFR" eventType="touchUpInside" id="HhF-jb-L1F"/>
-                                </connections>
-                            </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Q44-lQ-i2t">
-                                <rect key="frame" x="0.0" y="165" width="1024" height="169"/>
-                            </imageView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hYV-4I-qf2" userLabel="ChoreNameView">
-                                <rect key="frame" x="0.0" y="104" width="1024" height="61"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chore Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kG9-JB-EhE">
-                                        <rect key="frame" x="440" y="15.5" width="145" height="30"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="kG9-JB-EhE" firstAttribute="centerX" secondItem="hYV-4I-qf2" secondAttribute="centerX" id="f5j-ak-Hm2"/>
-                                    <constraint firstItem="kG9-JB-EhE" firstAttribute="centerY" secondItem="hYV-4I-qf2" secondAttribute="centerY" id="iuF-vd-TNj"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3kX-7h-Lvb" userLabel="UsernameView">
-                                <rect key="frame" x="0.0" y="334" width="1024" height="46"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8rK-SS-e9D">
-                                        <rect key="frame" x="512" y="23" width="0.0" height="0.0"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="8rK-SS-e9D" firstAttribute="centerX" secondItem="3kX-7h-Lvb" secondAttribute="centerX" id="snX-eX-9Fr"/>
-                                    <constraint firstItem="8rK-SS-e9D" firstAttribute="centerY" secondItem="3kX-7h-Lvb" secondAttribute="centerY" id="vTa-GV-Ck5"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PLA-Fp-Car" userLabel="DescriptionView">
-                                <rect key="frame" x="0.0" y="380" width="1024" height="100"/>
-                                <subviews>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CS1-zd-ylj">
-                                        <rect key="frame" x="51.5" y="5.5" width="921" height="90"/>
-                                        <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="CS1-zd-ylj" firstAttribute="centerY" secondItem="PLA-Fp-Car" secondAttribute="centerY" id="25F-hi-LJx"/>
-                                    <constraint firstItem="CS1-zd-ylj" firstAttribute="width" secondItem="PLA-Fp-Car" secondAttribute="width" multiplier="0.9" id="ahZ-LA-1gx"/>
-                                    <constraint firstItem="CS1-zd-ylj" firstAttribute="height" secondItem="PLA-Fp-Car" secondAttribute="height" multiplier="0.9" id="ey0-lF-JAB"/>
-                                    <constraint firstItem="CS1-zd-ylj" firstAttribute="centerX" secondItem="PLA-Fp-Car" secondAttribute="centerX" id="wxO-TQ-lUh"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3bZ-rQ-oqY" userLabel="DatesView">
-                                <rect key="frame" x="0.0" y="480" width="1024" height="112"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r9y-UW-Jjt">
-                                        <rect key="frame" x="0.0" y="0.0" width="338.5" height="112"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/DD/YYYY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FwK-SV-FeU">
-                                                <rect key="frame" x="124" y="47.5" width="89" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="swI-Re-UQq">
-                                                <rect key="frame" x="124" y="22.5" width="89" height="17"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="FwK-SV-FeU" firstAttribute="centerX" secondItem="r9y-UW-Jjt" secondAttribute="centerX" id="8IE-Uf-ukc"/>
-                                            <constraint firstItem="FwK-SV-FeU" firstAttribute="top" secondItem="swI-Re-UQq" secondAttribute="bottom" constant="8" id="EW0-bo-Nzg"/>
-                                            <constraint firstItem="FwK-SV-FeU" firstAttribute="centerY" secondItem="r9y-UW-Jjt" secondAttribute="centerY" id="IoZ-GE-Sv2"/>
-                                            <constraint firstItem="swI-Re-UQq" firstAttribute="centerX" secondItem="FwK-SV-FeU" secondAttribute="centerX" id="UB5-Ju-PZD"/>
-                                            <constraint firstItem="swI-Re-UQq" firstAttribute="width" secondItem="FwK-SV-FeU" secondAttribute="width" id="wcc-Hg-puk"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r0b-NV-aYu">
-                                        <rect key="frame" x="338.5" y="0.0" width="348" height="112"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/DD/YYYY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KO2-4e-Xiw">
-                                                <rect key="frame" x="129.5" y="47.5" width="89" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Due Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JLv-St-xGH">
-                                                <rect key="frame" x="129.5" y="22.5" width="89" height="17"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="JLv-St-xGH" firstAttribute="width" secondItem="KO2-4e-Xiw" secondAttribute="width" id="5dT-kB-DuE"/>
-                                            <constraint firstItem="KO2-4e-Xiw" firstAttribute="top" secondItem="JLv-St-xGH" secondAttribute="bottom" constant="8" id="QiU-2f-azZ"/>
-                                            <constraint firstItem="JLv-St-xGH" firstAttribute="centerX" secondItem="KO2-4e-Xiw" secondAttribute="centerX" id="aJW-ko-SLA"/>
-                                            <constraint firstItem="KO2-4e-Xiw" firstAttribute="centerX" secondItem="r0b-NV-aYu" secondAttribute="centerX" id="geX-wR-Mip"/>
-                                            <constraint firstItem="KO2-4e-Xiw" firstAttribute="centerY" secondItem="r0b-NV-aYu" secondAttribute="centerY" id="vqh-eh-eWp"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MI0-h8-R11">
-                                        <rect key="frame" x="686.5" y="0.0" width="337.5" height="112"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chore Value" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RGb-vN-pzL">
-                                                <rect key="frame" x="127.5" y="18.5" width="84" height="17"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="srM-gj-pbB">
-                                                <rect key="frame" x="127.5" y="43.5" width="84" height="24"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="RGb-vN-pzL" firstAttribute="centerX" secondItem="srM-gj-pbB" secondAttribute="centerX" id="Y4f-dd-ibk"/>
-                                            <constraint firstItem="RGb-vN-pzL" firstAttribute="width" secondItem="srM-gj-pbB" secondAttribute="width" id="ah8-HB-9kS"/>
-                                            <constraint firstItem="srM-gj-pbB" firstAttribute="top" secondItem="RGb-vN-pzL" secondAttribute="bottom" constant="8" id="mPx-si-BWD"/>
-                                            <constraint firstItem="srM-gj-pbB" firstAttribute="centerY" secondItem="MI0-h8-R11" secondAttribute="centerY" id="p1I-io-WFa"/>
-                                            <constraint firstItem="srM-gj-pbB" firstAttribute="centerX" secondItem="MI0-h8-R11" secondAttribute="centerX" id="pVJ-YA-luy"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="MI0-h8-R11" firstAttribute="leading" secondItem="r0b-NV-aYu" secondAttribute="trailing" id="0CI-aJ-XiQ"/>
-                                    <constraint firstItem="MI0-h8-R11" firstAttribute="width" secondItem="3bZ-rQ-oqY" secondAttribute="width" multiplier="0.33" id="1eg-5A-yBQ"/>
-                                    <constraint firstItem="r0b-NV-aYu" firstAttribute="leading" secondItem="r9y-UW-Jjt" secondAttribute="trailing" id="9fF-8P-59c"/>
-                                    <constraint firstItem="MI0-h8-R11" firstAttribute="height" secondItem="3bZ-rQ-oqY" secondAttribute="height" id="AeW-x4-Pco"/>
-                                    <constraint firstItem="r0b-NV-aYu" firstAttribute="top" secondItem="3bZ-rQ-oqY" secondAttribute="top" id="GkW-Ec-Z3Y"/>
-                                    <constraint firstAttribute="bottom" secondItem="MI0-h8-R11" secondAttribute="bottom" id="PVx-En-Hog"/>
-                                    <constraint firstItem="r9y-UW-Jjt" firstAttribute="leading" secondItem="3bZ-rQ-oqY" secondAttribute="leading" id="U16-N5-CgR"/>
-                                    <constraint firstAttribute="bottom" secondItem="r0b-NV-aYu" secondAttribute="bottom" id="WpP-Uc-Mrg"/>
-                                    <constraint firstItem="r9y-UW-Jjt" firstAttribute="width" secondItem="3bZ-rQ-oqY" secondAttribute="width" multiplier="0.33" id="YB5-Xg-Brm"/>
-                                    <constraint firstAttribute="trailing" secondItem="MI0-h8-R11" secondAttribute="trailing" id="ZMA-nH-6PA"/>
-                                    <constraint firstAttribute="bottom" secondItem="r9y-UW-Jjt" secondAttribute="bottom" id="ajg-pA-6yu"/>
-                                    <constraint firstItem="r9y-UW-Jjt" firstAttribute="height" secondItem="3bZ-rQ-oqY" secondAttribute="height" id="fdq-Bf-KMy"/>
-                                    <constraint firstItem="MI0-h8-R11" firstAttribute="top" secondItem="3bZ-rQ-oqY" secondAttribute="top" id="m8a-hr-ltm"/>
-                                    <constraint firstItem="r9y-UW-Jjt" firstAttribute="top" secondItem="3bZ-rQ-oqY" secondAttribute="top" id="xLV-il-2w8"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2v7-P8-Pls" userLabel="NotesView">
-                                <rect key="frame" x="0.0" y="591.5" width="1024" height="99.5"/>
-                                <subviews>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VmY-QH-8F3">
-                                        <rect key="frame" x="51.5" y="5.5" width="921" height="90"/>
-                                        <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="VmY-QH-8F3" firstAttribute="height" secondItem="2v7-P8-Pls" secondAttribute="height" multiplier="0.9" id="5q7-aS-WQA"/>
-                                    <constraint firstItem="VmY-QH-8F3" firstAttribute="width" secondItem="2v7-P8-Pls" secondAttribute="width" multiplier="0.9" id="bra-5U-ehj"/>
-                                    <constraint firstItem="VmY-QH-8F3" firstAttribute="centerY" secondItem="2v7-P8-Pls" secondAttribute="centerY" id="chs-CJ-bHv"/>
-                                    <constraint firstItem="VmY-QH-8F3" firstAttribute="centerX" secondItem="2v7-P8-Pls" secondAttribute="centerX" id="noX-Uf-vHN"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="11T-zB-so7" userLabel="MarkCompleteView">
-                                <rect key="frame" x="0.0" y="691" width="1024" height="77"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mS5-Qp-9J1">
-                                        <rect key="frame" x="102" y="12.5" width="819" height="53.5"/>
-                                        <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
-                                        <state key="normal" title="MARK AS COMPLETE" backgroundImage="btnGreen_L">
-                                            <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="markComplete:" destination="6dG-q3-qFR" eventType="touchUpInside" id="BrT-tO-sPh"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="mS5-Qp-9J1" firstAttribute="centerX" secondItem="11T-zB-so7" secondAttribute="centerX" id="BOC-aj-nex"/>
-                                    <constraint firstItem="mS5-Qp-9J1" firstAttribute="width" secondItem="11T-zB-so7" secondAttribute="width" multiplier="0.8" id="Bmz-7m-hbE"/>
-                                    <constraint firstItem="mS5-Qp-9J1" firstAttribute="centerY" secondItem="11T-zB-so7" secondAttribute="centerY" id="Q5Y-u5-F3D"/>
-                                    <constraint firstItem="mS5-Qp-9J1" firstAttribute="height" secondItem="11T-zB-so7" secondAttribute="height" multiplier="0.7" id="VYG-SC-ec6"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ml9-ew-U3R" userLabel="CalcTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="54"/>
-                                <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="Pcd-nJ-hUZ">
-                                        <rect key="frame" x="0.0" y="0.0" width="1024" height="54"/>
-                                    </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rAW-4t-ayH">
-                                        <rect key="frame" x="8" y="8" width="37" height="37"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="rAW-4t-ayH" secondAttribute="height" id="62K-cP-VKl"/>
-                                        </constraints>
-                                        <state key="normal" backgroundImage="profilePic5"/>
-                                        <connections>
-                                            <segue destination="QRy-ch-Cyl" kind="presentation" id="3V0-eC-vGf"/>
-                                        </connections>
-                                    </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ENd-rF-5Y9">
-                                        <rect key="frame" x="53" y="11" width="120" height="30"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                        <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=regular-widthClass=regular">
-                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
-                                        </variation>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m1O-03-rf6">
-                                        <rect key="frame" x="948.5" y="12" width="17" height="30"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                        <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=regular-widthClass=regular">
-                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
-                                        </variation>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Xu-EU-nYV">
-                                        <rect key="frame" x="973.5" y="5" width="42.5" height="42.5"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="6Xu-EU-nYV" secondAttribute="height" id="qxP-EL-S5p"/>
-                                        </constraints>
-                                        <state key="normal" backgroundImage="coin"/>
-                                        <connections>
-                                            <action selector="toCoinView:" destination="6dG-q3-qFR" eventType="touchUpInside" id="aos-BZ-B7L"/>
-                                        </connections>
-                                    </button>
-                                    <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="nDP-pF-lhz">
-                                        <rect key="frame" x="1003" y="5" width="13" height="13"/>
-                                    </imageView>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="Pcd-nJ-hUZ" firstAttribute="height" secondItem="Ml9-ew-U3R" secondAttribute="height" id="6xx-X1-0s3"/>
-                                    <constraint firstItem="Pcd-nJ-hUZ" firstAttribute="width" secondItem="Ml9-ew-U3R" secondAttribute="width" id="8jr-ne-Jh8"/>
-                                    <constraint firstItem="ENd-rF-5Y9" firstAttribute="leading" secondItem="rAW-4t-ayH" secondAttribute="trailing" constant="8" id="8vi-dD-ktz"/>
-                                    <constraint firstAttribute="trailing" secondItem="6Xu-EU-nYV" secondAttribute="trailing" constant="8" id="Cwm-jg-UKY"/>
-                                    <constraint firstItem="nDP-pF-lhz" firstAttribute="height" secondItem="6Xu-EU-nYV" secondAttribute="height" multiplier="0.3" id="Jjr-0t-El2"/>
-                                    <constraint firstItem="rAW-4t-ayH" firstAttribute="leading" secondItem="Ml9-ew-U3R" secondAttribute="leading" constant="8" id="M74-r4-0hW"/>
-                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ENd-rF-5Y9" secondAttribute="trailing" constant="20" symbolic="YES" id="MFd-En-a8b"/>
-                                    <constraint firstItem="Pcd-nJ-hUZ" firstAttribute="centerX" secondItem="Ml9-ew-U3R" secondAttribute="centerX" id="NyL-qV-9Al"/>
-                                    <constraint firstItem="nDP-pF-lhz" firstAttribute="trailing" secondItem="6Xu-EU-nYV" secondAttribute="trailing" id="PJ5-9P-ZCy"/>
-                                    <constraint firstItem="ENd-rF-5Y9" firstAttribute="centerY" secondItem="rAW-4t-ayH" secondAttribute="centerY" id="Pdv-Qf-53A"/>
-                                    <constraint firstItem="6Xu-EU-nYV" firstAttribute="height" secondItem="Ml9-ew-U3R" secondAttribute="height" multiplier="0.8" id="PgZ-aR-JlZ"/>
-                                    <constraint firstItem="6Xu-EU-nYV" firstAttribute="leading" secondItem="m1O-03-rf6" secondAttribute="trailing" constant="8" id="VDE-fd-ccz"/>
-                                    <constraint firstItem="rAW-4t-ayH" firstAttribute="centerY" secondItem="Ml9-ew-U3R" secondAttribute="centerY" id="Wwa-cG-VqX"/>
-                                    <constraint firstItem="nDP-pF-lhz" firstAttribute="width" secondItem="nDP-pF-lhz" secondAttribute="height" multiplier="1:1" id="X9i-i4-xxG"/>
-                                    <constraint firstItem="m1O-03-rf6" firstAttribute="centerY" secondItem="6Xu-EU-nYV" secondAttribute="centerY" id="gcS-j9-XbF"/>
-                                    <constraint firstItem="rAW-4t-ayH" firstAttribute="height" secondItem="Ml9-ew-U3R" secondAttribute="height" multiplier="0.7" id="mI0-pt-p5T"/>
-                                    <constraint firstItem="m1O-03-rf6" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ml9-ew-U3R" secondAttribute="leading" constant="20" symbolic="YES" id="tgw-Q0-A6h"/>
-                                    <constraint firstItem="6Xu-EU-nYV" firstAttribute="centerY" secondItem="Ml9-ew-U3R" secondAttribute="centerY" id="uPF-GW-iD1"/>
-                                    <constraint firstItem="Pcd-nJ-hUZ" firstAttribute="centerY" secondItem="Ml9-ew-U3R" secondAttribute="centerY" id="xEU-9E-fdc"/>
-                                    <constraint firstItem="nDP-pF-lhz" firstAttribute="top" secondItem="6Xu-EU-nYV" secondAttribute="top" id="zaz-d4-4fa"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t1y-5I-zRn" userLabel="RedeemChildView">
-                                <rect key="frame" x="512" y="66" width="512" height="76.5"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vvl-9o-AAI">
-                                        <rect key="frame" x="0.0" y="14.5" width="512" height="48"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                        <state key="normal" title="REDEEM">
-                                            <color key="titleColor" red="0.1327331853" green="0.1327331853" blue="0.1327331853" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="childRedeem:" destination="0aj-d2-s3B" eventType="touchUpInside" id="0qX-CT-Bo1"/>
-                                            <action selector="childRedeem:" destination="6dG-q3-qFR" eventType="touchUpInside" id="2wk-Cy-jNX"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="0.79917594179999996" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstItem="Vvl-9o-AAI" firstAttribute="centerX" secondItem="t1y-5I-zRn" secondAttribute="centerX" id="4K2-ME-gUe"/>
-                                    <constraint firstItem="Vvl-9o-AAI" firstAttribute="width" secondItem="t1y-5I-zRn" secondAttribute="width" id="UxQ-Bx-d8P"/>
-                                    <constraint firstItem="Vvl-9o-AAI" firstAttribute="centerY" secondItem="t1y-5I-zRn" secondAttribute="centerY" id="q1N-8W-hiu"/>
-                                </constraints>
-                            </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xJ5-9p-txG">
-                                <rect key="frame" x="8" y="74" width="48" height="30"/>
-                                <state key="normal" title="&lt; Back"/>
-                                <connections>
-                                    <action selector="doGoBack:" destination="6dG-q3-qFR" eventType="touchUpInside" id="OHI-zg-62M"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="1Xe-Ns-90J"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="bSq-U0-DY5" secondAttribute="trailing" constant="8" id="26a-df-mJA"/>
-                            <constraint firstItem="PLA-Fp-Car" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="3Kb-1t-qFn"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xJ5-9p-txG" secondAttribute="trailing" constant="20" symbolic="YES" id="3az-tQ-wG4"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="t1y-5I-zRn" secondAttribute="trailing" id="4cV-3L-1hX"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="4eV-sr-zaG"/>
-                            <constraint firstItem="11T-zB-so7" firstAttribute="top" secondItem="2v7-P8-Pls" secondAttribute="bottom" id="6Et-UA-nry"/>
-                            <constraint firstItem="t1y-5I-zRn" firstAttribute="top" secondItem="Ml9-ew-U3R" secondAttribute="bottom" constant="-8" id="6dK-oB-0hg"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="2v7-P8-Pls" secondAttribute="trailing" id="7xY-Gp-KbA"/>
-                            <constraint firstItem="xJ5-9p-txG" firstAttribute="top" secondItem="Ml9-ew-U3R" secondAttribute="bottom" id="8ak-3O-jZW"/>
-                            <constraint firstItem="FHk-kR-gff" firstAttribute="width" secondItem="OZG-HX-J5A" secondAttribute="width" id="94Z-5a-v5H"/>
-                            <constraint firstItem="2v7-P8-Pls" firstAttribute="top" secondItem="3bZ-rQ-oqY" secondAttribute="bottom" id="9eB-F7-7Cx"/>
-                            <constraint firstItem="3kX-7h-Lvb" firstAttribute="top" secondItem="Q44-lQ-i2t" secondAttribute="bottom" id="9iC-iI-3a0"/>
-                            <constraint firstItem="FHk-kR-gff" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" id="Bvi-SZ-3fT"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="trailing" secondItem="egl-NY-Sae" secondAttribute="trailing" id="C9j-6S-U7r"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="Cxg-WO-DH5"/>
-                            <constraint firstItem="11T-zB-so7" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.1" id="E51-w4-RA6"/>
-                            <constraint firstItem="3kX-7h-Lvb" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.06" id="Ehc-5z-ElW"/>
-                            <constraint firstItem="2v7-P8-Pls" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.13" id="I81-8Q-epE"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="11T-zB-so7" secondAttribute="trailing" id="KSq-gA-l6v"/>
-                            <constraint firstItem="t1y-5I-zRn" firstAttribute="width" secondItem="OZG-HX-J5A" secondAttribute="width" multiplier="0.5" id="LAZ-cy-f13"/>
-                            <constraint firstItem="Ml9-ew-U3R" firstAttribute="top" secondItem="egl-NY-Sae" secondAttribute="top" id="LMb-Zg-3M5"/>
-                            <constraint firstItem="bSq-U0-DY5" firstAttribute="top" secondItem="Ml9-ew-U3R" secondAttribute="bottom" id="M5f-bC-svB"/>
-                            <constraint firstItem="xJ5-9p-txG" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" constant="8" id="Mkp-Ua-cPb"/>
-                            <constraint firstItem="FHk-kR-gff" firstAttribute="centerY" secondItem="egl-NY-Sae" secondAttribute="centerY" id="N96-OK-JxS"/>
-                            <constraint firstItem="FHk-kR-gff" firstAttribute="centerX" secondItem="egl-NY-Sae" secondAttribute="centerX" id="O5c-9j-mud"/>
-                            <constraint firstItem="xJ5-9p-txG" firstAttribute="top" secondItem="Ml9-ew-U3R" secondAttribute="bottom" id="RXh-gq-kn1"/>
-                            <constraint firstItem="3bZ-rQ-oqY" firstAttribute="top" secondItem="PLA-Fp-Car" secondAttribute="bottom" id="S49-ff-f3y"/>
-                            <constraint firstItem="PLA-Fp-Car" firstAttribute="top" secondItem="3kX-7h-Lvb" secondAttribute="bottom" id="SVb-ul-zwu"/>
-                            <constraint firstItem="Ml9-ew-U3R" firstAttribute="trailing" secondItem="egl-NY-Sae" secondAttribute="trailing" id="TZx-uO-ssD"/>
-                            <constraint firstItem="Q44-lQ-i2t" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.22" id="Xl8-Jz-D48"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="top" secondItem="xJ5-9p-txG" secondAttribute="bottom" id="YuY-ER-xeG"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="trailing" secondItem="egl-NY-Sae" secondAttribute="trailing" id="bzq-7c-5hv"/>
-                            <constraint firstItem="Q44-lQ-i2t" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="cGh-k4-gBU"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="trailing" secondItem="egl-NY-Sae" secondAttribute="trailing" id="cuM-p1-6Ke"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.08" id="dWw-1Z-wb7"/>
-                            <constraint firstItem="bSq-U0-DY5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="OZG-HX-J5A" secondAttribute="leading" constant="20" symbolic="YES" id="eh8-VI-mnW"/>
-                            <constraint firstItem="Q44-lQ-i2t" firstAttribute="trailing" secondItem="egl-NY-Sae" secondAttribute="trailing" id="ggK-kx-kR5"/>
-                            <constraint firstItem="xJ5-9p-txG" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" constant="8" id="jAZ-Cw-4tc"/>
-                            <constraint firstItem="xJ5-9p-txG" firstAttribute="top" secondItem="Ml9-ew-U3R" secondAttribute="bottom" id="l6g-Oa-h1P"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="3kX-7h-Lvb" secondAttribute="trailing" id="lWj-yL-Oxi"/>
-                            <constraint firstItem="xJ5-9p-txG" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" constant="8" id="m1i-C0-D25"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="PLA-Fp-Car" secondAttribute="trailing" id="p5w-Sn-0MB"/>
-                            <constraint firstItem="Q44-lQ-i2t" firstAttribute="top" secondItem="hYV-4I-qf2" secondAttribute="bottom" id="py5-D7-qQB"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="3bZ-rQ-oqY" secondAttribute="trailing" id="qPj-2v-J1m"/>
-                            <constraint firstItem="PLA-Fp-Car" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.13" id="qj8-M9-SsY"/>
-                            <constraint firstItem="11T-zB-so7" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="sE1-lM-pxC"/>
-                            <constraint firstItem="2v7-P8-Pls" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="t7G-MA-3V4"/>
-                            <constraint firstItem="Ml9-ew-U3R" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="t8Q-YN-kiL"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="top" secondItem="xJ5-9p-txG" secondAttribute="bottom" id="tJx-Yg-1Mz"/>
-                            <constraint firstItem="3bZ-rQ-oqY" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="tZ3-Ps-fp5"/>
-                            <constraint firstItem="Ml9-ew-U3R" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.07" id="w93-XO-DsP"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="trailing" secondItem="bSq-U0-DY5" secondAttribute="trailing" constant="8" id="wR4-HC-IQD"/>
-                            <constraint firstItem="egl-NY-Sae" firstAttribute="bottom" secondItem="11T-zB-so7" secondAttribute="bottom" id="wSF-k9-VfJ"/>
-                            <constraint firstItem="t1y-5I-zRn" firstAttribute="height" secondItem="OZG-HX-J5A" secondAttribute="height" multiplier="0.1" id="ylX-uo-6pc"/>
-                            <constraint firstItem="hYV-4I-qf2" firstAttribute="top" secondItem="bSq-U0-DY5" secondAttribute="bottom" id="zBX-gd-oUx"/>
-                            <constraint firstItem="3kX-7h-Lvb" firstAttribute="leading" secondItem="egl-NY-Sae" secondAttribute="leading" id="zCI-cd-Dck"/>
-                        </constraints>
-                        <viewLayoutGuide key="safeArea" id="egl-NY-Sae"/>
-                    </view>
-                    <connections>
-                        <outlet property="bgImage" destination="FHk-kR-gff" id="EIO-F6-KRY"/>
-                        <outlet property="childRedeemView" destination="t1y-5I-zRn" id="RLa-I1-XK1"/>
-                        <outlet property="choreDescriptionTextView" destination="CS1-zd-ylj" id="2kd-RN-Zt3"/>
-                        <outlet property="choreImageImageView" destination="Q44-lQ-i2t" id="14O-uo-SOw"/>
-                        <outlet property="choreNameLabel" destination="kG9-JB-EhE" id="9Z1-tT-2iP"/>
-                        <outlet property="choreNoteTextView" destination="VmY-QH-8F3" id="vSD-5e-H1d"/>
-                        <outlet property="choreValueLabel" destination="srM-gj-pbB" id="Xeu-HC-U0Q"/>
-                        <outlet property="coinAmtLabel" destination="m1O-03-rf6" id="7J0-Sa-UYD"/>
-                        <outlet property="completedBtn" destination="mS5-Qp-9J1" id="eAi-OK-zcH"/>
-                        <outlet property="detailImageHeightConstraint" destination="Xl8-Jz-D48" id="4II-ah-IRb"/>
-                        <outlet property="dueDateLabel" destination="KO2-4e-Xiw" id="wpJ-gu-GFs"/>
-                        <outlet property="editUIButton" destination="bSq-U0-DY5" id="MLZ-HJ-4Nf"/>
-                        <outlet property="headerUserNameLabel" destination="ENd-rF-5Y9" id="Kxe-lY-swL"/>
-                        <outlet property="profileButton" destination="rAW-4t-ayH" id="c4C-gv-ajo"/>
-                        <outlet property="redDot" destination="nDP-pF-lhz" id="OgL-Mu-t2u"/>
-                        <outlet property="startDateLabel" destination="FwK-SV-FeU" id="hnE-tj-tnf"/>
-                        <outlet property="usernameLabel" destination="8rK-SS-e9D" id="764-F7-mX8"/>
-                        <segue destination="q0I-az-h0x" kind="presentation" identifier="toCoinFromChoreDetails" id="GCd-rR-cmP"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="1eU-Dy-PB4" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-506" y="1702"/>
-        </scene>
         <!--Take Picture View Controller-->
         <scene sceneID="VGY-H7-B2W">
             <objects>
                 <viewController id="qhd-Nu-lX1" customClass="TakePictureViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="s4Z-hu-I3M">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="883.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="7Ar-Lw-kr3">
-                                <rect key="frame" x="0.0" y="10" width="1024" height="645"/>
+                                <rect key="frame" x="0.0" y="10" width="768" height="883.5"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AAT-X3-lHs">
-                                <rect key="frame" x="0.0" y="95" width="1024" height="245.5"/>
+                                <rect key="frame" x="0.0" y="112" width="768" height="335.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="niceWork" translatesAutoresizingMaskIntoConstraints="NO" id="fap-2v-KdD">
-                                        <rect key="frame" x="205.5" y="24" width="613" height="196.5"/>
+                                        <rect key="frame" x="77.5" y="33" width="613" height="268.5"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -3443,10 +3106,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LTq-iJ-Q3t" userLabel="MarkCompleteView">
-                                <rect key="frame" x="0.0" y="516" width="1024" height="129"/>
+                                <rect key="frame" x="0.0" y="707" width="768" height="176.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B78-mR-i0a">
-                                        <rect key="frame" x="102" y="42.5" width="819" height="44.5"/>
+                                        <rect key="frame" x="76.5" y="57.5" width="614" height="61.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="TAKE PICTURE" backgroundImage="btnOrange_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3465,10 +3128,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ruq-it-bIh">
-                                <rect key="frame" x="0.0" y="340.5" width="1024" height="175.5"/>
+                                <rect key="frame" x="0.0" y="447.5" width="768" height="259.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Take a picture to show that you completed this chore." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ace-qs-AeT">
-                                        <rect key="frame" x="102.5" y="8.5" width="819.5" height="26.5"/>
+                                        <rect key="frame" x="77" y="8.5" width="614.5" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -3485,13 +3148,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rcS-Jw-Ff5" userLabel="CalcTopBarView">
-                                <rect key="frame" x="0.0" y="20" width="1024" height="45"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="62"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="topBar_L" translatesAutoresizingMaskIntoConstraints="NO" id="uxn-js-JMJ">
-                                        <rect key="frame" x="0.0" y="0.0" width="1024" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="62"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="be6-Zc-DSa">
-                                        <rect key="frame" x="8" y="6.5" width="31" height="31"/>
+                                        <rect key="frame" x="8" y="9" width="43" height="43"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="be6-Zc-DSa" secondAttribute="height" id="eMz-ZJ-AyA"/>
                                         </constraints>
@@ -3501,7 +3164,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BAb-Up-N4G">
-                                        <rect key="frame" x="47" y="7.5" width="120" height="30"/>
+                                        <rect key="frame" x="59" y="16" width="120" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -3510,7 +3173,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Icj-xH-Lr3">
-                                        <rect key="frame" x="955" y="7.5" width="17" height="30"/>
+                                        <rect key="frame" x="685.5" y="16" width="17" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -3519,7 +3182,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9HQ-G7-tR6">
-                                        <rect key="frame" x="980" y="4" width="36" height="36"/>
+                                        <rect key="frame" x="710.5" y="6" width="49.5" height="49"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="9HQ-G7-tR6" secondAttribute="height" id="pz4-pg-UvS"/>
                                         </constraints>
@@ -3529,7 +3192,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="redDot" translatesAutoresizingMaskIntoConstraints="NO" id="ClS-xB-fAV">
-                                        <rect key="frame" x="1005" y="4" width="11" height="10.5"/>
+                                        <rect key="frame" x="746" y="6" width="14" height="14"/>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -3557,17 +3220,17 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WkB-KB-mbN">
-                                <rect key="frame" x="8" y="65" width="48" height="30"/>
+                                <rect key="frame" x="8" y="82" width="48" height="30"/>
                                 <state key="normal" title="&lt; Back"/>
                                 <connections>
                                     <action selector="doGoBack:" destination="qhd-Nu-lX1" eventType="touchUpInside" id="uGL-7B-lg9"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KkM-I9-Co9" userLabel="RedeemChildView">
-                                <rect key="frame" x="512" y="57" width="512" height="64.5"/>
+                                <rect key="frame" x="560.5" y="74" width="207.5" height="88"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pz6-hi-7zd">
-                                        <rect key="frame" x="0.0" y="9" width="512" height="48"/>
+                                        <rect key="frame" x="0.0" y="20.5" width="207.5" height="48"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                         <state key="normal" title="REDEEM">
                                             <color key="titleColor" red="0.1327331853" green="0.1327331853" blue="0.1327331853" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3592,6 +3255,7 @@
                             <constraint firstItem="WkB-KB-mbN" firstAttribute="leading" secondItem="SND-6o-v3F" secondAttribute="leading" constant="8" id="6Hu-De-hRq"/>
                             <constraint firstItem="AAT-X3-lHs" firstAttribute="leading" secondItem="SND-6o-v3F" secondAttribute="leading" id="9Xu-U1-zMY"/>
                             <constraint firstItem="WkB-KB-mbN" firstAttribute="leading" secondItem="SND-6o-v3F" secondAttribute="leading" constant="8" id="9wX-GN-i0K"/>
+                            <constraint firstItem="KkM-I9-Co9" firstAttribute="width" secondItem="s4Z-hu-I3M" secondAttribute="width" multiplier="0.27" id="EcH-0w-sin"/>
                             <constraint firstItem="SND-6o-v3F" firstAttribute="bottom" secondItem="LTq-iJ-Q3t" secondAttribute="bottom" id="ExR-Pd-w8n"/>
                             <constraint firstItem="LTq-iJ-Q3t" firstAttribute="trailing" secondItem="SND-6o-v3F" secondAttribute="trailing" id="FQw-tv-Odo"/>
                             <constraint firstItem="7Ar-Lw-kr3" firstAttribute="centerX" secondItem="SND-6o-v3F" secondAttribute="centerX" id="HYm-Re-UEI"/>
@@ -3617,6 +3281,17 @@
                             <constraint firstItem="SND-6o-v3F" firstAttribute="trailing" secondItem="AAT-X3-lHs" secondAttribute="trailing" id="wwN-EX-sc4"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="SND-6o-v3F"/>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="EcH-0w-sin"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <include reference="EcH-0w-sin"/>
+                                <exclude reference="iqv-Sv-HpA"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
                         <outlet property="bgImage" destination="7Ar-Lw-kr3" id="kBR-Co-LXQ"/>
@@ -3662,24 +3337,24 @@
             <objects>
                 <viewController id="YPH-HZ-alo" customClass="ChoresDetailSplitViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QD0-tx-aRf">
-                        <rect key="frame" x="0.0" y="0.0" width="703.5" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="447.5" height="883.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="OBJ-Pl-dDb">
-                                <rect key="frame" x="0.0" y="20" width="703.5" height="625"/>
+                                <rect key="frame" x="0.0" y="20" width="447.5" height="863.5"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hoe-hW-lgU">
-                                <rect key="frame" x="665.5" y="20" width="30" height="30"/>
+                                <rect key="frame" x="409.5" y="20" width="30" height="30"/>
                                 <state key="normal" title="Edit"/>
                                 <connections>
                                     <action selector="editChoreBtn:" destination="YPH-HZ-alo" eventType="touchUpInside" id="Xqg-VN-LJA"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jeo-Zb-uzp" userLabel="ChoreNameView">
-                                <rect key="frame" x="0.0" y="50" width="703.5" height="51.5"/>
+                                <rect key="frame" x="0.0" y="50" width="447.5" height="70.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chore Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kRu-Y7-VSz">
-                                        <rect key="frame" x="279.5" y="11" width="145" height="30"/>
+                                        <rect key="frame" x="151.5" y="20.5" width="145" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -3692,13 +3367,13 @@
                                 </constraints>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fIv-eO-o4G">
-                                <rect key="frame" x="0.0" y="101.5" width="703.5" height="142"/>
+                                <rect key="frame" x="0.0" y="120.5" width="447.5" height="194.5"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lXH-d6-gG5" userLabel="UsernameView">
-                                <rect key="frame" x="0.0" y="243.5" width="703.5" height="45"/>
+                                <rect key="frame" x="0.0" y="315" width="447.5" height="62"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1rd-JA-QZP">
-                                        <rect key="frame" x="352.5" y="22" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="224.5" y="30.5" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -3711,10 +3386,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sLQ-rG-n2b" userLabel="DescriptionView">
-                                <rect key="frame" x="0.0" y="288.5" width="703.5" height="84"/>
+                                <rect key="frame" x="0.0" y="377" width="447.5" height="115"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3dN-cM-P81">
-                                        <rect key="frame" x="35.5" y="4" width="632.5" height="75"/>
+                                        <rect key="frame" x="22.5" y="5" width="402.5" height="103.5"/>
                                         <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -3729,19 +3404,19 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sy9-06-ydx" userLabel="DatesView">
-                                <rect key="frame" x="0.0" y="372.5" width="703.5" height="77.5"/>
+                                <rect key="frame" x="0.0" y="492" width="447.5" height="106"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvL-sR-t5N">
-                                        <rect key="frame" x="0.0" y="0.5" width="232" height="77.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="147.5" height="106"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/DD/YYYY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQ0-E4-Ci4">
-                                                <rect key="frame" x="71" y="30" width="89" height="17"/>
+                                                <rect key="frame" x="28.5" y="44.5" width="89" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RZ8-R1-6dH">
-                                                <rect key="frame" x="71" y="5" width="89" height="17"/>
+                                                <rect key="frame" x="28.5" y="19.5" width="89" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -3757,16 +3432,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HNH-qr-wCh">
-                                        <rect key="frame" x="232" y="0.5" width="239.5" height="77.5"/>
+                                        <rect key="frame" x="147.5" y="0.0" width="152.5" height="106"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MM/DD/YYYY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bC4-CY-AZm">
-                                                <rect key="frame" x="76" y="30" width="89" height="17"/>
+                                                <rect key="frame" x="32.5" y="44.5" width="89" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Due Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDM-yK-SPs">
-                                                <rect key="frame" x="76" y="5" width="89" height="17"/>
+                                                <rect key="frame" x="32.5" y="19.5" width="89" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -3782,16 +3457,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8nh-Zn-NI5">
-                                        <rect key="frame" x="471.5" y="0.5" width="232" height="77.5"/>
+                                        <rect key="frame" x="300" y="0.0" width="147.5" height="106"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chore Value" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2qC-nf-8TQ">
-                                                <rect key="frame" x="74.5" y="1.5" width="84" height="17"/>
+                                                <rect key="frame" x="32" y="16" width="84" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JZC-9z-9qp">
-                                                <rect key="frame" x="74.5" y="26.5" width="84" height="24"/>
+                                                <rect key="frame" x="32" y="41" width="84" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -3826,10 +3501,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oRN-lT-fMQ" userLabel="NotesView">
-                                <rect key="frame" x="0.0" y="450" width="703.5" height="130.5"/>
+                                <rect key="frame" x="0.0" y="598" width="447.5" height="197"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TqE-sJ-AaN">
-                                        <rect key="frame" x="35.5" y="6.5" width="632.5" height="118"/>
+                                        <rect key="frame" x="22.5" y="10" width="402.5" height="178"/>
                                         <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -3844,10 +3519,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P6f-QJ-9aY" userLabel="MarkCompleteView">
-                                <rect key="frame" x="0.0" y="580.5" width="703.5" height="64.5"/>
+                                <rect key="frame" x="0.0" y="795" width="447.5" height="88.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EM1-IY-mUr">
-                                        <rect key="frame" x="70" y="10.5" width="562.5" height="44.5"/>
+                                        <rect key="frame" x="44.5" y="14" width="358" height="61.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="MARK AS COMPLETE" backgroundImage="btnGreen_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3866,7 +3541,7 @@
                                 </constraints>
                             </view>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cd5-zH-SQE">
-                                <rect key="frame" x="0.0" y="0.0" width="703" height="645"/>
+                                <rect key="frame" x="0.0" y="0.0" width="447.5" height="883.5"/>
                                 <connections>
                                     <segue destination="l7o-YR-ylh" kind="embed" identifier="editEmbedSegue" id="xXJ-L9-K5s"/>
                                 </connections>
@@ -3941,7 +3616,7 @@
             <objects>
                 <tableViewController clearsSelectionOnViewWillAppear="NO" id="WKc-Ml-U7n" customClass="ChoresMasterTableViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="rsq-xK-RPk">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="883.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -3992,12 +3667,13 @@
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8B9-PE-suW">
                                                     <rect key="frame" x="-0.5" y="0.0" width="95" height="65"/>
+                                                    <color key="backgroundColor" red="1" green="0.0" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="8B9-PE-suW" secondAttribute="height" multiplier="54:37" id="LGt-7v-uSL"/>
                                                     </constraints>
                                                 </imageView>
                                             </subviews>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstItem="8B9-PE-suW" firstAttribute="centerX" secondItem="Jxv-Nb-EvZ" secondAttribute="centerX" id="7sx-tk-PMX"/>
                                                 <constraint firstItem="8B9-PE-suW" firstAttribute="height" secondItem="Jxv-Nb-EvZ" secondAttribute="height" id="9ii-0Z-9BA"/>
@@ -4114,17 +3790,17 @@
             <objects>
                 <viewController id="l7o-YR-ylh" customClass="ChoreEditViewController" customModule="ChoresForCoinsiOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cE1-P8-MYr">
-                        <rect key="frame" x="0.0" y="0.0" width="703" height="645"/>
+                        <rect key="frame" x="0.0" y="0.0" width="447.5" height="883.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="whiteBG" translatesAutoresizingMaskIntoConstraints="NO" id="iep-6D-Xq4">
-                                <rect key="frame" x="0.0" y="10" width="703" height="645"/>
+                                <rect key="frame" x="0.0" y="10" width="447.5" height="883.5"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ygz-WW-UmH" userLabel="DescriptionView">
-                                <rect key="frame" x="0.0" y="290.5" width="703" height="83.5"/>
+                                <rect key="frame" x="0.0" y="376" width="447.5" height="115"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Chore Description: Put away all toys in my room." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="csA-wP-sc1">
-                                        <rect key="frame" x="35.5" y="0.0" width="632" height="83.5"/>
+                                        <rect key="frame" x="22.5" y="0.0" width="402.5" height="115"/>
                                         <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -4138,22 +3814,25 @@
                                     <constraint firstItem="csA-wP-sc1" firstAttribute="width" secondItem="ygz-WW-UmH" secondAttribute="width" multiplier="0.9" id="vsN-h3-2Ve"/>
                                 </constraints>
                             </view>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0Ig-cD-hxn" userLabel="ChoreImageView">
+                                <rect key="frame" x="0.5" y="129" width="447.5" height="194.5"/>
+                            </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UVS-cT-pfm">
-                                <rect key="frame" x="0.0" y="110" width="703" height="141.5"/>
+                                <rect key="frame" x="0.0" y="128.5" width="447.5" height="194.5"/>
                                 <color key="backgroundColor" red="0.88094383478164673" green="0.5873374342918396" blue="0.083256371319293976" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <state key="normal">
-                                    <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="changeChorePicture:" destination="l7o-YR-ylh" eventType="touchUpInside" id="CVj-Qx-Rm0"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ubp-0f-Fbk" userLabel="UsernameView">
-                                <rect key="frame" x="0.0" y="251.5" width="703" height="39"/>
+                                <rect key="frame" x="0.0" y="323" width="447.5" height="53"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ef5-EW-iQY">
-                                        <rect key="frame" x="71" y="4" width="562" height="30"/>
+                                        <rect key="frame" x="45.5" y="11" width="357.5" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <textInputTraits key="textInputTraits"/>
@@ -4167,10 +3846,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IJ8-tv-5Me" userLabel="ChoreNameView">
-                                <rect key="frame" x="0.0" y="58" width="703" height="52"/>
+                                <rect key="frame" x="0.0" y="58" width="447.5" height="70.5"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="CHORE NAME" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FdJ-1J-Csf">
-                                        <rect key="frame" x="71" y="9" width="562" height="34"/>
+                                        <rect key="frame" x="45.5" y="18" width="357.5" height="34"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                         <textInputTraits key="textInputTraits"/>
@@ -4184,10 +3863,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5WR-tm-l0U" userLabel="NotesView">
-                                <rect key="frame" x="0.0" y="496.5" width="703" height="84"/>
+                                <rect key="frame" x="0.0" y="680.5" width="447.5" height="114.5"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="zg2-SZ-F4w">
-                                        <rect key="frame" x="35.5" y="4.5" width="632" height="75.5"/>
+                                        <rect key="frame" x="22.5" y="6" width="402.5" height="103"/>
                                         <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -4202,19 +3881,19 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DUM-el-Z3f" userLabel="DatesView">
-                                <rect key="frame" x="0.0" y="374" width="703" height="122.5"/>
+                                <rect key="frame" x="0.0" y="491" width="447.5" height="189.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1CF-98-fSD">
-                                        <rect key="frame" x="0.0" y="0.5" width="232.5" height="122"/>
+                                        <rect key="frame" x="0.0" y="0.5" width="148.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r83-dp-DJu">
-                                                <rect key="frame" x="23" y="21.5" width="186.5" height="17"/>
+                                                <rect key="frame" x="14.5" y="55" width="119" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dCP-6f-1HZ">
-                                                <rect key="frame" x="23" y="46.5" width="186" height="30"/>
+                                                <rect key="frame" x="14.5" y="80" width="118.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -4231,16 +3910,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wJk-v0-Con">
-                                        <rect key="frame" x="232.5" y="0.5" width="238" height="122"/>
+                                        <rect key="frame" x="148.5" y="0.5" width="150.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Due Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zEC-U9-Fyg">
-                                                <rect key="frame" x="23" y="21.5" width="191" height="17"/>
+                                                <rect key="frame" x="14.5" y="55" width="120.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LaJ-Vj-bhm">
-                                                <rect key="frame" x="23.5" y="46.5" width="191" height="30"/>
+                                                <rect key="frame" x="15" y="80" width="120.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -4257,16 +3936,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2iD-Iz-8OQ">
-                                        <rect key="frame" x="470.5" y="0.5" width="232.5" height="122"/>
+                                        <rect key="frame" x="299" y="0.5" width="148.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chore Value" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qvY-06-eRh">
-                                                <rect key="frame" x="23.5" y="21.5" width="186" height="17"/>
+                                                <rect key="frame" x="15.5" y="55" width="118.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="10" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OBi-Ax-d5A">
-                                                <rect key="frame" x="23.5" y="46.5" width="186" height="30"/>
+                                                <rect key="frame" x="15.5" y="80" width="118.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
@@ -4302,10 +3981,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jPM-I3-E3A" userLabel="BottomButtonsView">
-                                <rect key="frame" x="0.0" y="580.5" width="703" height="64.5"/>
+                                <rect key="frame" x="0.0" y="795" width="447.5" height="88.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O0Q-xf-KRO">
-                                        <rect key="frame" x="36.5" y="12" width="294" height="42.5"/>
+                                        <rect key="frame" x="25" y="16" width="185.5" height="58.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="DELETE" backgroundImage="btnRed_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -4315,11 +3994,11 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pi2-j2-N7x">
-                                        <rect key="frame" x="330.5" y="29.5" width="42" height="6.5"/>
+                                        <rect key="frame" x="210.5" y="40" width="26.5" height="9"/>
                                         <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Oa-x0-NsH">
-                                        <rect key="frame" x="372.5" y="11.5" width="294" height="42"/>
+                                        <rect key="frame" x="237" y="15.5" width="185.5" height="58.5"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="18"/>
                                         <state key="normal" title="SAVE" backgroundImage="btnGreen_L">
                                             <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -4363,6 +4042,7 @@
                             <constraint firstItem="c3g-ZU-90Y" firstAttribute="top" secondItem="fL4-fh-c3O" secondAttribute="top" constant="8" id="4Rr-PH-620"/>
                             <constraint firstItem="c3g-ZU-90Y" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" constant="8" id="6H1-7z-Xqm"/>
                             <constraint firstItem="IJ8-tv-5Me" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="6NO-Sj-slt"/>
+                            <constraint firstItem="0Ig-cD-hxn" firstAttribute="width" secondItem="UVS-cT-pfm" secondAttribute="width" id="7YJ-kr-YPY"/>
                             <constraint firstItem="IJ8-tv-5Me" firstAttribute="top" secondItem="c3g-ZU-90Y" secondAttribute="bottom" id="8TZ-ez-R75"/>
                             <constraint firstItem="fL4-fh-c3O" firstAttribute="trailing" secondItem="ubp-0f-Fbk" secondAttribute="trailing" id="98L-Jx-OLZ"/>
                             <constraint firstItem="iep-6D-Xq4" firstAttribute="height" secondItem="cE1-P8-MYr" secondAttribute="height" id="9gd-uQ-ydV"/>
@@ -4375,6 +4055,7 @@
                             <constraint firstItem="5WR-tm-l0U" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="HKZ-br-mID"/>
                             <constraint firstItem="ygz-WW-UmH" firstAttribute="top" secondItem="ubp-0f-Fbk" secondAttribute="bottom" id="Ha6-Pj-vkH"/>
                             <constraint firstItem="jPM-I3-E3A" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="IW8-5R-2b7"/>
+                            <constraint firstItem="0Ig-cD-hxn" firstAttribute="centerX" secondItem="UVS-cT-pfm" secondAttribute="centerX" id="JgK-s9-X63"/>
                             <constraint firstItem="DUM-el-Z3f" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="JnJ-Nh-vvb"/>
                             <constraint firstItem="5WR-tm-l0U" firstAttribute="height" secondItem="cE1-P8-MYr" secondAttribute="height" multiplier="0.13" id="Kuq-lC-crs"/>
                             <constraint firstItem="jPM-I3-E3A" firstAttribute="bottom" secondItem="fL4-fh-c3O" secondAttribute="bottom" id="MLm-Po-X71"/>
@@ -4382,6 +4063,7 @@
                             <constraint firstItem="ubp-0f-Fbk" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="NOg-rd-uRc"/>
                             <constraint firstItem="ubp-0f-Fbk" firstAttribute="trailing" secondItem="fL4-fh-c3O" secondAttribute="trailing" id="OBY-AW-3YH"/>
                             <constraint firstItem="UVS-cT-pfm" firstAttribute="top" secondItem="IJ8-tv-5Me" secondAttribute="bottom" id="OXV-15-PBE"/>
+                            <constraint firstItem="0Ig-cD-hxn" firstAttribute="centerY" secondItem="UVS-cT-pfm" secondAttribute="centerY" id="Ove-4i-HHs"/>
                             <constraint firstItem="iep-6D-Xq4" firstAttribute="centerX" secondItem="fL4-fh-c3O" secondAttribute="centerX" id="OzF-tH-wka"/>
                             <constraint firstItem="UVS-cT-pfm" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="RoA-iJ-pS8"/>
                             <constraint firstItem="fL4-fh-c3O" firstAttribute="trailing" secondItem="5WR-tm-l0U" secondAttribute="trailing" id="SPG-1t-tXv"/>
@@ -4399,14 +4081,21 @@
                             <constraint firstItem="IJ8-tv-5Me" firstAttribute="top" secondItem="c3g-ZU-90Y" secondAttribute="bottom" id="tFb-tf-B1X"/>
                             <constraint firstItem="jPM-I3-E3A" firstAttribute="top" secondItem="5WR-tm-l0U" secondAttribute="bottom" id="vMX-jA-veY"/>
                             <constraint firstItem="ubp-0f-Fbk" firstAttribute="height" secondItem="cE1-P8-MYr" secondAttribute="height" multiplier="0.06" id="wZL-pb-aZC"/>
+                            <constraint firstItem="0Ig-cD-hxn" firstAttribute="height" secondItem="UVS-cT-pfm" secondAttribute="height" id="x65-JJ-Qa1"/>
                             <constraint firstItem="ubp-0f-Fbk" firstAttribute="leading" secondItem="fL4-fh-c3O" secondAttribute="leading" id="y7g-Va-x1F"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="fL4-fh-c3O"/>
                     </view>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="choreImageUIButton.imageView.contentMode">
+                            <integer key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
                     <connections>
                         <outlet property="bgImage" destination="iep-6D-Xq4" id="a8t-RH-tgy"/>
                         <outlet property="choreDescriptionTextView" destination="csA-wP-sc1" id="aM9-jX-Dgx"/>
                         <outlet property="choreImageUIButton" destination="UVS-cT-pfm" id="ASq-eV-OWx"/>
+                        <outlet property="choreImageView" destination="0Ig-cD-hxn" id="6H3-jp-aKb"/>
                         <outlet property="choreNameTextField" destination="FdJ-1J-Csf" id="7u7-lT-423"/>
                         <outlet property="choreNoteTextView" destination="zg2-SZ-F4w" id="0AR-fc-0y6"/>
                         <outlet property="choreValueTextField" destination="OBi-Ax-d5A" id="Ck3-2m-NpS"/>
@@ -4463,10 +4152,10 @@
         </namedColor>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="0ls-Pt-Ljb"/>
+        <segue reference="Gxm-IN-KRx"/>
         <segue reference="bm7-WQ-ArU"/>
         <segue reference="q0e-xW-FaS"/>
-        <segue reference="0dr-E4-ccy"/>
-        <segue reference="w4o-uD-FV8"/>
+        <segue reference="TW0-XL-iud"/>
+        <segue reference="OXB-qQ-rBy"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/ChoresForCoinsiOS/ViewControllers/ChoreEditViewController.swift
+++ b/ChoresForCoinsiOS/ViewControllers/ChoreEditViewController.swift
@@ -16,6 +16,7 @@ class ChoreEditViewController: UIViewController, UIImagePickerControllerDelegate
     // MARK: - Outlets
     
     @IBOutlet weak var choreImageUIButton: UIButton!
+    @IBOutlet weak var choreImageView: UIImageView!
     @IBOutlet weak var choreNameTextField: UITextField!
     @IBOutlet weak var usernameTextField: UITextField!
     @IBOutlet weak var choreDescriptionTextView: UITextView!
@@ -57,13 +58,9 @@ class ChoreEditViewController: UIViewController, UIImagePickerControllerDelegate
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        choreImageUIButton.imageView?.contentMode = .scaleAspectFit
-        
         choreValueTextField.delegate = self
         choreNameTextField.delegate = self
         usernameTextField.delegate = self
-        
-        getBackground()
         
         //gets the firebase generated id
         userID = (Auth.auth().currentUser?.uid)!
@@ -89,6 +86,7 @@ class ChoreEditViewController: UIViewController, UIImagePickerControllerDelegate
     
     override func viewWillAppear(_ animated: Bool) {
         isUserParent()
+        getBackground()
     }
     
     override func didReceiveMemoryWarning() {
@@ -394,9 +392,10 @@ class ChoreEditViewController: UIViewController, UIImagePickerControllerDelegate
                     }
                     
                     if let imageUrl = value?["image_url"] as? String {
-                        self.choreImageUIButton.loadImagesUsingCacheWithUrlString(urlString: imageUrl, inViewController: self)
+                        self.choreImageView.loadImagesUsingCacheWithUrlString(urlString: imageUrl, inViewController: self)
                     } else if self.imageHeightConstraint != nil {
                         self.imageHeightConstraint.isActive = false
+                        self.choreImageView.isHidden = true
                         self.choreImageUIButton.isHidden = true
                         let heightConstraint = NSLayoutConstraint(item: self.choreImageUIButton, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: nil, attribute: NSLayoutAttribute.notAnAttribute, multiplier: 0.00000001, constant: 0)
                         heightConstraint.isActive = true

--- a/ChoresForCoinsiOS/ViewControllers/ChoreListViewController.swift
+++ b/ChoresForCoinsiOS/ViewControllers/ChoreListViewController.swift
@@ -381,6 +381,18 @@ class ChoreListViewController: UIViewController {
             }
         }
     }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "toCoinFromChoresList" {
+            if let destination = segue.destination as? ParentCoinChildViewController {
+                destination.fromDetailsOrEdit = true
+                destination.children = self.children
+                destination.coinTotals = self.coinTotals
+            }
+        }
+    }
+    
+    
     // MARK: Actions
     
     @IBAction func toCoinView(_ sender: UIButton) {

--- a/ChoresForCoinsiOS/ViewControllers/ChoresDetailSplitViewController.swift
+++ b/ChoresForCoinsiOS/ViewControllers/ChoresDetailSplitViewController.swift
@@ -351,6 +351,7 @@ class ChoresDetailSplitViewController: UIViewController {
     
     @IBAction func markComplete(_ sender: UIButton) {
         addCoins()
+        self.performSegue(withIdentifier: "takePictureSegue", sender: nil)
     }
     
     @IBAction func editChoreBtn(_ sender: UIButton) {
@@ -378,6 +379,7 @@ class ChoresDetailSplitViewController: UIViewController {
                 } else {
                     //gets the firebase generated id
                     userID = (Auth.auth().currentUser?.uid)!
+                    choreId = senderVC.choreId
                     getChoreData()
                     
                     //gets the custom parent id created in the registration

--- a/ChoresForCoinsiOS/ViewControllers/OverviewViewController.swift
+++ b/ChoresForCoinsiOS/ViewControllers/OverviewViewController.swift
@@ -523,7 +523,7 @@ class OverviewViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
-            return 600.0
+            return 800.0
         }
         
         return 432.0

--- a/ChoresForCoinsiOS/ViewControllers/ParentCoinChildViewController.swift
+++ b/ChoresForCoinsiOS/ViewControllers/ParentCoinChildViewController.swift
@@ -19,6 +19,7 @@ class ParentCoinChildViewController: UIViewController, UITableViewDataSource, UI
     @IBOutlet weak var bgImage: UIImageView!
     
     var ref: DatabaseReference?
+    var fromDetailsOrEdit: Bool? = false
     var coinValue = 11
     var idFound = false
     var firstRun = true
@@ -50,11 +51,27 @@ class ParentCoinChildViewController: UIViewController, UITableViewDataSource, UI
         
         getParentId()
         
-        // gets all children with same parent id as user
-        getChildren()
-        
-        // gets coin totals for all children
-        getCoinTotals()
+        if fromDetailsOrEdit! {
+            childrenTableView.reloadData()
+            
+            var sumTotal = 0
+            
+            for coinAmt in coinTotals{
+                if let total = coinAmt.cointotal{
+                    sumTotal += total
+                }
+            }
+            coinAmtLabel.text = String(sumTotal)
+            
+            fromDetailsOrEdit = false
+            
+        } else {
+            // gets all children with same parent id as user
+            getChildren()
+            
+            // gets coin totals for all children
+            getCoinTotals()
+        }
         
         // get photo for profile button
         getPhoto()
@@ -77,8 +94,26 @@ class ParentCoinChildViewController: UIViewController, UITableViewDataSource, UI
     
     override func viewWillAppear(_ animated: Bool) {
         if !firstRun {
-            coinValue = 0
-            getRunningTotalParent()
+            
+            if fromDetailsOrEdit! {
+                childrenTableView.reloadData()
+                
+                var sumTotal = 0
+                
+                for coinAmt in coinTotals{
+                    if let total = coinAmt.cointotal{
+                        sumTotal += total
+                    }
+                }
+                coinAmtLabel.text = String(sumTotal)
+                
+                fromDetailsOrEdit = false
+                
+            } else {
+                coinValue = 0
+                getRunningTotalParent()
+            }
+            
             // get photo for profile button
             getPhoto()
             
@@ -262,6 +297,10 @@ class ParentCoinChildViewController: UIViewController, UITableViewDataSource, UI
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         selectedCellIndex = indexPath.row
         performSegue(withIdentifier: "goToCalc", sender: self)
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100.0
     }
     
     @IBAction func dismissView(_ sender: Any) {

--- a/ChoresForCoinsiOS/ViewControllers/SettingsViewController.swift
+++ b/ChoresForCoinsiOS/ViewControllers/SettingsViewController.swift
@@ -23,8 +23,10 @@ class SettingsViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var coinValView: UIView!
     @IBOutlet weak var bonusDayView: UIView!
     @IBOutlet weak var BonusMultView: UIView!
-    @IBOutlet weak var coinValHeight: NSLayoutConstraint!
-    @IBOutlet weak var coinValHeightiPad: NSLayoutConstraint!
+    @IBOutlet weak var backgroundWidthSafeiPad: NSLayoutConstraint!
+    @IBOutlet weak var backgroundWidthSuperiPad: NSLayoutConstraint!
+    @IBOutlet weak var backgroundView: UIView!
+    @IBOutlet var settingsSuperView: UIView!
     
     var isFirstLoad = true
     var coinValue = 0
@@ -371,7 +373,6 @@ class SettingsViewController: UIViewController, UITextFieldDelegate {
                     self.coinValView.isHidden = true
                     self.bonusDayView.isHidden = true
                     self.BonusMultView.isHidden = true
-                    
                 }
             }
         })


### PR DESCRIPTION
- made it so the image in the chore edit view is scaleAspectFit
- in chore edit view, made it so the back button doesn't wipe out data from details view
- in parentCoinChildView, made table cells taller
- fixed issue in parentCoinChildView where if you segued to the view from the chore details or edit views, the table view would be empty
- Animations are playing in the simulator. still need to check on devices
- hid skip button